### PR TITLE
Revert converting the attenuator controls to spin boxes

### DIFF
--- a/atcaLLRF.ui
+++ b/atcaLLRF.ui
@@ -807,7 +807,7 @@ QTabBar::tab:left:only-one, QTabBar::tab:right:only-one {
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
-                   <width>40</width>
+                   <width>10</width>
                    <height>20</height>
                   </size>
                  </property>
@@ -1425,7 +1425,7 @@ QPushButton:hover{
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
-                   <width>40</width>
+                   <width>10</width>
                    <height>20</height>
                   </size>
                  </property>

--- a/atcaLLRF.ui
+++ b/atcaLLRF.ui
@@ -807,7 +807,7 @@ QTabBar::tab:left:only-one, QTabBar::tab:right:only-one {
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
-                   <width>10</width>
+                   <width>40</width>
                    <height>20</height>
                   </size>
                  </property>
@@ -1425,7 +1425,7 @@ QPushButton:hover{
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
-                   <width>10</width>
+                   <width>40</width>
                    <height>20</height>
                   </size>
                  </property>

--- a/down_converter.ui
+++ b/down_converter.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>282</width>
-    <height>184</height>
+    <height>172</height>
    </rect>
   </property>
   <property name="font">
@@ -37,59 +37,8 @@
    <property name="verticalSpacing">
     <number>4</number>
    </property>
-   <item row="7" column="0">
-    <widget class="QLabel" name="label_11">
-     <property name="font">
-      <font>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="styleSheet">
-      <string notr="true"/>
-     </property>
-     <property name="text">
-      <string>RF IN 3</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="0">
-    <widget class="QLabel" name="label_10">
-     <property name="font">
-      <font>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="styleSheet">
-      <string notr="true"/>
-     </property>
-     <property name="text">
-      <string>RF IN 4</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="label_8">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="font">
-      <font>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="styleSheet">
-      <string notr="true"/>
-     </property>
-     <property name="text">
-      <string>RF IN 2</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="3">
-    <widget class="PyDMLabel" name="PyDMLabel_3">
+   <item row="8" column="1">
+    <widget class="PyDMLineEdit" name="PyDMLineEdit_3">
      <property name="font">
       <font>
        <pointsize>8</pointsize>
@@ -101,45 +50,36 @@
      <property name="styleSheet">
       <string notr="true"/>
      </property>
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="scaledContents">
+     <property name="showUnits" stdset="0">
       <bool>true</bool>
      </property>
      <property name="channel" stdset="0">
-      <string>ca://${DEVICE}:DNC_TEMP3</string>
+      <string>ca://${DEVICE}:DNC_ATTEN3</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
-    <widget class="QLabel" name="label">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>1</horstretch>
-       <verstretch>1</verstretch>
-      </sizepolicy>
-     </property>
+   <item row="10" column="1">
+    <widget class="PyDMLineEdit" name="PyDMLineEdit_5">
      <property name="font">
       <font>
        <pointsize>8</pointsize>
       </font>
      </property>
+     <property name="toolTip">
+      <string/>
+     </property>
      <property name="styleSheet">
       <string notr="true"/>
      </property>
-     <property name="text">
-      <string>Att.</string>
+     <property name="showUnits" stdset="0">
+      <bool>true</bool>
      </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
+     <property name="channel" stdset="0">
+      <string>ca://${DEVICE}:DNC_ATTEN5</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="3">
+   <item row="6" column="2">
     <widget class="PyDMLabel" name="PyDMLabel">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -172,8 +112,44 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="3">
-    <widget class="QLabel" name="label_17">
+   <item row="6" column="0">
+    <widget class="QLabel" name="label_8">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="text">
+      <string>RF IN 2</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="label_11">
+     <property name="font">
+      <font>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="text">
+      <string>RF IN 3</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QLabel" name="label">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>1</horstretch>
@@ -189,29 +165,41 @@
       <string notr="true"/>
      </property>
      <property name="text">
-      <string>Temp.</string>
+      <string>Att.</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label_9">
+   <item row="8" column="2">
+    <widget class="PyDMLabel" name="PyDMLabel_3">
      <property name="font">
       <font>
        <pointsize>8</pointsize>
       </font>
      </property>
+     <property name="toolTip">
+      <string/>
+     </property>
      <property name="styleSheet">
       <string notr="true"/>
      </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
      <property name="text">
-      <string>RF IN 1</string>
+      <string/>
+     </property>
+     <property name="scaledContents">
+      <bool>true</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${DEVICE}:DNC_TEMP3</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="3">
+   <item row="5" column="2">
     <widget class="PyDMLabel" name="PyDMLabel_2">
      <property name="font">
       <font>
@@ -235,6 +223,171 @@
      </property>
      <property name="channel" stdset="0">
       <string>ca://${DEVICE}:DNC_TEMP0</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="2">
+    <widget class="QLabel" name="label_17">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>1</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="text">
+      <string>Temp.</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0">
+    <widget class="QLabel" name="label_10">
+     <property name="font">
+      <font>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="text">
+      <string>RF IN 4</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_9">
+     <property name="font">
+      <font>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="text">
+      <string>RF IN 1</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="PyDMLineEdit" name="PyDMLineEdit_4">
+     <property name="font">
+      <font>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="showUnits" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${DEVICE}:DNC_ATTEN2</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1">
+    <widget class="PyDMLineEdit" name="PyDMLineEdit">
+     <property name="font">
+      <font>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="showUnits" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${DEVICE}:DNC_ATTEN1</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1">
+    <widget class="PyDMLineEdit" name="PyDMLineEdit_6">
+     <property name="font">
+      <font>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="showUnits" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${DEVICE}:DNC_ATTEN4</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="2">
+    <widget class="PyDMLabel" name="PyDMLabel_4">
+     <property name="font">
+      <font>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="scaledContents">
+      <bool>true</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${DEVICE}:DNC_TEMP2</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="PyDMLineEdit" name="PyDMLineEdit_2">
+     <property name="font">
+      <font>
+       <pointsize>8</pointsize>
+      </font>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="showUnits" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${DEVICE}:DNC_ATTEN0</string>
      </property>
     </widget>
    </item>
@@ -268,165 +421,6 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="3">
-    <widget class="PyDMLabel" name="PyDMLabel_4">
-     <property name="font">
-      <font>
-       <pointsize>8</pointsize>
-      </font>
-     </property>
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="styleSheet">
-      <string notr="true"/>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="scaledContents">
-      <bool>true</bool>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${DEVICE}:DNC_TEMP2</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="PyDMSpinbox" name="PyDMSpinbox">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="prefix">
-      <string/>
-     </property>
-     <property name="suffix">
-      <string/>
-     </property>
-     <property name="decimals">
-      <number>0</number>
-     </property>
-     <property name="singleStep">
-      <double>0.500000000000000</double>
-     </property>
-     <property name="showUnits" stdset="0">
-      <bool>true</bool>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${DEVICE}:DNC_ATTEN0</string>
-     </property>
-     <property name="precision" stdset="0">
-      <number>0</number>
-     </property>
-     <property name="showStepExponent" stdset="0">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1">
-    <widget class="PyDMSpinbox" name="PyDMSpinbox_2">
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="singleStep">
-      <double>0.500000000000000</double>
-     </property>
-     <property name="showUnits" stdset="0">
-      <bool>true</bool>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${DEVICE}:DNC_ATTEN1</string>
-     </property>
-     <property name="showStepExponent" stdset="0">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="1">
-    <widget class="PyDMSpinbox" name="PyDMSpinbox_3">
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="singleStep">
-      <double>0.500000000000000</double>
-     </property>
-     <property name="showUnits" stdset="0">
-      <bool>true</bool>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${DEVICE}:DNC_ATTEN2</string>
-     </property>
-     <property name="showStepExponent" stdset="0">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="1">
-    <widget class="PyDMSpinbox" name="PyDMSpinbox_4">
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="singleStep">
-      <double>0.500000000000000</double>
-     </property>
-     <property name="showUnits" stdset="0">
-      <bool>true</bool>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${DEVICE}:DNC_ATTEN3</string>
-     </property>
-     <property name="showStepExponent" stdset="0">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="1">
-    <widget class="PyDMSpinbox" name="PyDMSpinbox_5">
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="singleStep">
-      <double>0.500000000000000</double>
-     </property>
-     <property name="showUnits" stdset="0">
-      <bool>true</bool>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${DEVICE}:DNC_ATTEN4</string>
-     </property>
-     <property name="showStepExponent" stdset="0">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="1">
-    <widget class="PyDMSpinbox" name="PyDMSpinbox_6">
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="singleStep">
-      <double>0.500000000000000</double>
-     </property>
-     <property name="showUnits" stdset="0">
-      <bool>true</bool>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${DEVICE}:DNC_ATTEN5</string>
-     </property>
-     <property name="showStepExponent" stdset="0">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -436,9 +430,9 @@
    <header>pydm.widgets.label</header>
   </customwidget>
   <customwidget>
-   <class>PyDMSpinbox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>pydm.widgets.spinbox</header>
+   <class>PyDMLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>pydm.widgets.line_edit</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/up_converter.ui
+++ b/up_converter.ui
@@ -79,6 +79,22 @@
      </property>
     </widget>
    </item>
+   <item row="5" column="1">
+    <widget class="PyDMLineEdit" name="PyDMLineEdit_9">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="showUnits" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${DEVICE}:UPC_ATTEN2</string>
+     </property>
+    </widget>
+   </item>
    <item row="5" column="2">
     <widget class="PyDMLabel" name="PyDMLabel_4">
      <property name="font">
@@ -154,6 +170,38 @@
      </property>
      <property name="text">
       <string>RF IN 1</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="PyDMLineEdit" name="PyDMLineEdit_13">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="showUnits" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${DEVICE}:UPC_ATTEN1</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="PyDMLineEdit" name="PyDMLineEdit_12">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="showUnits" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${DEVICE}:UPC_ATTEN0</string>
      </property>
     </widget>
    </item>
@@ -265,6 +313,22 @@
      </property>
     </widget>
    </item>
+   <item row="4" column="1">
+    <widget class="PyDMLineEdit" name="PyDMLineEdit_15">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="showUnits" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${DEVICE}:UPC_ATTEN3</string>
+     </property>
+    </widget>
+   </item>
    <item row="4" column="0">
     <widget class="QLabel" name="label_22">
      <property name="font">
@@ -295,82 +359,6 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="PyDMSpinbox" name="PyDMSpinbox">
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="singleStep">
-      <double>0.500000000000000</double>
-     </property>
-     <property name="showUnits" stdset="0">
-      <bool>true</bool>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${DEVICE}:UPC_ATTEN0</string>
-     </property>
-     <property name="showStepExponent" stdset="0">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="PyDMSpinbox" name="PyDMSpinbox_2">
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="singleStep">
-      <double>0.500000000000000</double>
-     </property>
-     <property name="showUnits" stdset="0">
-      <bool>true</bool>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${DEVICE}:UPC_ATTEN1</string>
-     </property>
-     <property name="showStepExponent" stdset="0">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="PyDMSpinbox" name="PyDMSpinbox_3">
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="singleStep">
-      <double>0.500000000000000</double>
-     </property>
-     <property name="showUnits" stdset="0">
-      <bool>true</bool>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${DEVICE}:UPC_ATTEN3</string>
-     </property>
-     <property name="showStepExponent" stdset="0">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="PyDMSpinbox" name="PyDMSpinbox_4">
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="singleStep">
-      <double>0.500000000000000</double>
-     </property>
-     <property name="showUnits" stdset="0">
-      <bool>true</bool>
-     </property>
-     <property name="channel" stdset="0">
-      <string>ca://${DEVICE}:UPC_ATTEN2</string>
-     </property>
-     <property name="showStepExponent" stdset="0">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -380,9 +368,9 @@
    <header>pydm.widgets.label</header>
   </customwidget>
   <customwidget>
-   <class>PyDMSpinbox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>pydm.widgets.spinbox</header>
+   <class>PyDMLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>pydm.widgets.line_edit</header>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
Revert some changes done in #104, specifically converting the control to spin boxes