### PR TITLE
HLS: Reorganize the Windows PV displays

### DIFF
--- a/hls_complex_window.ui
+++ b/hls_complex_window.ui
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>840</width>
+    <height>583</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="3" column="0">
+      <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton_2">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Define new waveforms</string>
+       </property>
+       <property name="filenames" stdset="0">
+        <stringlist>
+         <string>define_complex_window.py</string>
+        </stringlist>
+       </property>
+       <property name="macros" stdset="0">
+        <stringlist/>
+       </property>
+       <property name="openInNewWindow" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="2">
+      <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>IQ Measurement Waveforms</string>
+       </property>
+       <property name="filenames" stdset="0">
+        <stringlist>
+         <string>iqwaveform.ui</string>
+         <string>iqwaveform.ui</string>
+         <string>iqwaveform.ui</string>
+         <string>iqwaveform.ui</string>
+         <string>iqwaveform.ui</string>
+         <string>iqwaveform.ui</string>
+         <string>iqwaveform.ui</string>
+         <string>iqwaveform.ui</string>
+         <string>iqwaveform.ui</string>
+         <string>iqwaveform.ui</string>
+        </stringlist>
+       </property>
+       <property name="titles" stdset="0">
+        <stringlist>
+         <string>IQ-Waveform - DwnCon:RF_IN_1</string>
+         <string>IQ-Waveform - DwnCon:RF_IN_2</string>
+         <string>IQ-Waveform - DwnCon:RF_IN_3</string>
+         <string>IQ-Waveform - DwnCon:RF_IN_4</string>
+         <string>IQ-Waveform - DwnCon:RF_IN_5</string>
+         <string>IQ-Waveform - DwnCon:RF_IN_6</string>
+         <string>IQ-Waveform - UpCon:RF_IN_1</string>
+         <string>IQ-Waveform - UpCon:RF_IN_2</string>
+         <string>IQ-Waveform - UpCon:RF_IN_3</string>
+         <string>IQ-Waveform - UpCon:RF_OUT_MON</string>
+        </stringlist>
+       </property>
+       <property name="macros" stdset="0">
+        <stringlist>
+         <string>{&quot;N&quot;:&quot;1&quot;}</string>
+         <string>{&quot;N&quot;:&quot;0&quot;}</string>
+         <string>{&quot;N&quot;:&quot;3&quot;}</string>
+         <string>{&quot;N&quot;:&quot;2&quot;}</string>
+         <string>{&quot;N&quot;:&quot;5&quot;}</string>
+         <string>{&quot;N&quot;:&quot;4&quot;}</string>
+         <string>{&quot;N&quot;:&quot;7&quot;}</string>
+         <string>{&quot;N&quot;:&quot;6&quot;}</string>
+         <string>{&quot;N&quot;:&quot;8&quot;}</string>
+         <string>{&quot;N&quot;:&quot;9&quot;}</string>
+        </stringlist>
+       </property>
+       <property name="openInNewWindow" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0" colspan="3">
+      <widget class="PyDMWaveformPlot" name="PyDMWaveformPlot_5">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>1</horstretch>
+         <verstretch>1</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="showXGrid">
+        <bool>true</bool>
+       </property>
+       <property name="showYGrid">
+        <bool>true</bool>
+       </property>
+       <property name="showLegend">
+        <bool>true</bool>
+       </property>
+       <property name="curves">
+        <stringlist>
+         <string>{&quot;y_channel&quot;: &quot;ca://${DEVICE}:I${R}${N}&quot;, &quot;x_channel&quot;: null, &quot;name&quot;: &quot;I&quot;, &quot;color&quot;: &quot;#ff557f&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
+         <string>{&quot;y_channel&quot;: &quot;ca://${DEVICE}:Q${R}${N}&quot;, &quot;x_channel&quot;: null, &quot;name&quot;: &quot;Q&quot;, &quot;color&quot;: &quot;#5500ff&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="0" column="0" colspan="3">
+      <widget class="QLabel" name="label">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>${TITLE}</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMWaveformPlot</class>
+   <extends>QGraphicsView</extends>
+   <header>pydm.widgets.waveformplot</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMRelatedDisplayButton</class>
+   <extends>QPushButton</extends>
+   <header>pydm.widgets.related_display_button</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/llrf_hls.ui
+++ b/llrf_hls.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1023</width>
+    <width>1145</width>
     <height>1266</height>
    </rect>
   </property>
@@ -36,7 +36,7 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>1011</width>
+        <width>1133</width>
         <height>1254</height>
        </rect>
       </property>

--- a/llrf_hls.ui
+++ b/llrf_hls.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1012</width>
-    <height>1261</height>
+    <width>1023</width>
+    <height>1266</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -36,8 +36,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>1000</width>
-        <height>1301</height>
+        <width>1011</width>
+        <height>1254</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout_8">
@@ -3992,19 +3992,6 @@ Conversion Factor(kV/Count)</string>
           </widget>
          </item>
         </layout>
-       </item>
-       <item row="7" column="0">
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
        </item>
        <item row="3" column="0">
         <widget class="Line" name="line">

--- a/llrf_hls.ui
+++ b/llrf_hls.ui
@@ -37,7 +37,7 @@
         <x>0</x>
         <y>0</y>
         <width>1922</width>
-        <height>1325</height>
+        <height>1314</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout_8">
@@ -61,890 +61,8 @@
          </property>
         </widget>
        </item>
-       <item row="0" column="2" rowspan="5">
-        <layout class="QGridLayout" name="gridLayout_9" columnstretch="0,0">
-         <item row="5" column="0">
-          <widget class="PyDMWaveformPlot" name="PyDMWaveformPlot_6">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-             <horstretch>1</horstretch>
-             <verstretch>1</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="showXGrid">
-            <bool>true</bool>
-           </property>
-           <property name="showYGrid">
-            <bool>true</bool>
-           </property>
-           <property name="showLegend">
-            <bool>true</bool>
-           </property>
-           <property name="curves">
-            <stringlist>
-             <string>{&quot;y_channel&quot;: &quot;ca://${DEVICE}:ICPXWND1&quot;, &quot;x_channel&quot;: null, &quot;name&quot;: &quot;I&quot;, &quot;color&quot;: &quot;#ff557f&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
-             <string>{&quot;y_channel&quot;: &quot;ca://${DEVICE}:QCPXWND1&quot;, &quot;x_channel&quot;: null, &quot;name&quot;: &quot;Q&quot;, &quot;color&quot;: &quot;#5500ff&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
-            </stringlist>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <layout class="QHBoxLayout" name="horizontalLayout_3">
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <item>
-            <widget class="QLabel" name="label_57">
-             <property name="text">
-              <string>Feedback Complex Window</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton_2">
-             <property name="minimumSize">
-              <size>
-               <width>100</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>100</width>
-               <height>16777215</height>
-              </size>
-             </property>
-             <property name="toolTip">
-              <string/>
-             </property>
-             <property name="text">
-              <string>Define</string>
-             </property>
-             <property name="filenames" stdset="0">
-              <stringlist>
-               <string>define_complex_window.py</string>
-              </stringlist>
-             </property>
-             <property name="macros" stdset="0">
-              <stringlist>
-               <string>{&quot;TITLE&quot;:&quot;Baseband Complex Window&quot;, &quot;R&quot;:&quot;BL&quot;, &quot;N&quot;:&quot;&quot;}</string>
-              </stringlist>
-             </property>
-             <property name="openInNewWindow" stdset="0">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="8" column="0">
-          <widget class="PyDMWaveformPlot" name="PyDMWaveformPlot_7">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-             <horstretch>1</horstretch>
-             <verstretch>1</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="showXGrid">
-            <bool>true</bool>
-           </property>
-           <property name="showYGrid">
-            <bool>true</bool>
-           </property>
-           <property name="showLegend">
-            <bool>true</bool>
-           </property>
-           <property name="curves">
-            <stringlist>
-             <string>{&quot;y_channel&quot;: &quot;ca://${DEVICE}:ICPXWND2&quot;, &quot;x_channel&quot;: null, &quot;name&quot;: &quot;I&quot;, &quot;color&quot;: &quot;#ff557f&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
-             <string>{&quot;y_channel&quot;: &quot;ca://${DEVICE}:QCPXWND2&quot;, &quot;x_channel&quot;: null, &quot;name&quot;: &quot;Q&quot;, &quot;color&quot;: &quot;#5500ff&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
-            </stringlist>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="1">
-          <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="text">
-            <string>IQ Waveforms</string>
-           </property>
-           <property name="filenames" stdset="0">
-            <stringlist>
-             <string>iqwaveform.ui</string>
-             <string>iqwaveform.ui</string>
-             <string>iqwaveform.ui</string>
-             <string>iqwaveform.ui</string>
-             <string>iqwaveform.ui</string>
-             <string>iqwaveform.ui</string>
-             <string>iqwaveform.ui</string>
-             <string>iqwaveform.ui</string>
-             <string>iqwaveform.ui</string>
-             <string>iqwaveform.ui</string>
-            </stringlist>
-           </property>
-           <property name="titles" stdset="0">
-            <stringlist>
-             <string>IQ-Waveform - DwnCon:RF_IN_1</string>
-             <string>IQ-Waveform - DwnCon:RF_IN_2</string>
-             <string>IQ-Waveform - DwnCon:RF_IN_3</string>
-             <string>IQ-Waveform - DwnCon:RF_IN_4</string>
-             <string>IQ-Waveform - DwnCon:RF_IN_5</string>
-             <string>IQ-Waveform - DwnCon:RF_IN_6</string>
-             <string>IQ-Waveform - UpCon:RF_IN_1</string>
-             <string>IQ-Waveform - UpCon:RF_IN_2</string>
-             <string>IQ-Waveform - UpCon:RF_IN_3</string>
-             <string>IQ-Waveform - UpCon:RF_OUT_MON</string>
-            </stringlist>
-           </property>
-           <property name="macros" stdset="0">
-            <stringlist>
-             <string>{&quot;N&quot;:&quot;1&quot;}</string>
-             <string>{&quot;N&quot;:&quot;0&quot;}</string>
-             <string>{&quot;N&quot;:&quot;3&quot;}</string>
-             <string>{&quot;N&quot;:&quot;2&quot;}</string>
-             <string>{&quot;N&quot;:&quot;5&quot;}</string>
-             <string>{&quot;N&quot;:&quot;4&quot;}</string>
-             <string>{&quot;N&quot;:&quot;7&quot;}</string>
-             <string>{&quot;N&quot;:&quot;6&quot;}</string>
-             <string>{&quot;N&quot;:&quot;8&quot;}</string>
-             <string>{&quot;N&quot;:&quot;9&quot;}</string>
-            </stringlist>
-           </property>
-           <property name="openInNewWindow" stdset="0">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="PyDMWaveformPlot" name="PyDMWaveformPlot_5">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-             <horstretch>1</horstretch>
-             <verstretch>1</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="showXGrid">
-            <bool>true</bool>
-           </property>
-           <property name="showYGrid">
-            <bool>true</bool>
-           </property>
-           <property name="showLegend">
-            <bool>true</bool>
-           </property>
-           <property name="curves">
-            <stringlist>
-             <string>{&quot;y_channel&quot;: &quot;ca://${DEVICE}:ICPXWND0&quot;, &quot;x_channel&quot;: null, &quot;name&quot;: &quot;I&quot;, &quot;color&quot;: &quot;#ff557f&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
-             <string>{&quot;y_channel&quot;: &quot;ca://${DEVICE}:QCPXWND0&quot;, &quot;x_channel&quot;: null, &quot;name&quot;: &quot;Q&quot;, &quot;color&quot;: &quot;#5500ff&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
-            </stringlist>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="0">
-          <layout class="QHBoxLayout" name="horizontalLayout_5">
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <item>
-            <widget class="QLabel" name="label_59">
-             <property name="text">
-              <string>Diagnostics Complex Window 2</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton_4">
-             <property name="minimumSize">
-              <size>
-               <width>100</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>100</width>
-               <height>16777215</height>
-              </size>
-             </property>
-             <property name="toolTip">
-              <string/>
-             </property>
-             <property name="text">
-              <string>Define</string>
-             </property>
-             <property name="filenames" stdset="0">
-              <stringlist>
-               <string>define_complex_window.py</string>
-              </stringlist>
-             </property>
-             <property name="macros" stdset="0">
-              <stringlist>
-               <string>{&quot;TITLE&quot;:&quot;Baseband Complex Window&quot;, &quot;R&quot;:&quot;BL&quot;, &quot;N&quot;:&quot;&quot;}</string>
-              </stringlist>
-             </property>
-             <property name="openInNewWindow" stdset="0">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="4" column="0">
-          <layout class="QHBoxLayout" name="horizontalLayout_4">
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <item>
-            <widget class="QLabel" name="label_58">
-             <property name="text">
-              <string>Diagnostics Complex Window 1</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton_3">
-             <property name="minimumSize">
-              <size>
-               <width>100</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>100</width>
-               <height>16777215</height>
-              </size>
-             </property>
-             <property name="toolTip">
-              <string/>
-             </property>
-             <property name="text">
-              <string>Define</string>
-             </property>
-             <property name="filenames" stdset="0">
-              <stringlist>
-               <string>define_complex_window.py</string>
-              </stringlist>
-             </property>
-             <property name="macros" stdset="0">
-              <stringlist>
-               <string>{&quot;TITLE&quot;:&quot;Baseband Complex Window&quot;, &quot;R&quot;:&quot;BL&quot;, &quot;N&quot;:&quot;&quot;}</string>
-              </stringlist>
-             </property>
-             <property name="openInNewWindow" stdset="0">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="1" column="1">
-          <layout class="QHBoxLayout" name="horizontalLayout_2">
-           <item>
-            <widget class="QLabel" name="label_53">
-             <property name="text">
-              <string>Baseband I/Q Drive Waveforms</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton_5">
-             <property name="minimumSize">
-              <size>
-               <width>100</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>100</width>
-               <height>16777215</height>
-              </size>
-             </property>
-             <property name="toolTip">
-              <string/>
-             </property>
-             <property name="text">
-              <string>Define</string>
-             </property>
-             <property name="filenames" stdset="0">
-              <stringlist>
-               <string>define_complex_window.py</string>
-              </stringlist>
-             </property>
-             <property name="macros" stdset="0">
-              <stringlist>
-               <string>{&quot;TITLE&quot;:&quot;Baseband Complex Window&quot;, &quot;R&quot;:&quot;BL&quot;, &quot;N&quot;:&quot;&quot;}</string>
-              </stringlist>
-             </property>
-             <property name="openInNewWindow" stdset="0">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="2" column="1">
-          <widget class="PyDMWaveformPlot" name="PyDMWaveformPlot">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-             <horstretch>1</horstretch>
-             <verstretch>1</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="showXGrid">
-            <bool>true</bool>
-           </property>
-           <property name="showYGrid">
-            <bool>true</bool>
-           </property>
-           <property name="showLegend">
-            <bool>true</bool>
-           </property>
-           <property name="curves">
-            <stringlist>
-             <string>{&quot;y_channel&quot;: &quot;ca://${DEVICE}:IBL&quot;, &quot;x_channel&quot;: null, &quot;name&quot;: &quot;I&quot;, &quot;color&quot;: &quot;#ff557f&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
-             <string>{&quot;y_channel&quot;: &quot;ca://${DEVICE}:QBL&quot;, &quot;x_channel&quot;: null, &quot;name&quot;: &quot;Q&quot;, &quot;color&quot;: &quot;#5500ff&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
-            </stringlist>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
        <item row="4" column="0">
         <layout class="QGridLayout" name="gridLayout_2">
-         <item row="5" column="0">
-          <widget class="QLabel" name="label_24">
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>TS 5</string>
-           </property>
-          </widget>
-         </item>
-         <item row="10" column="4">
-          <widget class="PyDMLabel" name="PyDMLabel_163">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:ADES03</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="10">
-          <widget class="PyDMLabel" name="PyDMLabel_87">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PREF04</string>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="10">
-          <widget class="QLabel" name="label_33">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>1</horstretch>
-             <verstretch>1</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>AREF</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="6">
-          <widget class="QLabel" name="label_28">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>1</horstretch>
-             <verstretch>1</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>PACT</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="6">
-          <widget class="PyDMLabel" name="PyDMLabel_62">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PACT02</string>
-           </property>
-          </widget>
-         </item>
-         <item row="13" column="10">
-          <widget class="PyDMLabel" name="PyDMLabel_96">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AREF06</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QLabel" name="label_22">
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>TS 3</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0">
-          <widget class="QLabel" name="label_23">
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>TS 4</string>
-           </property>
-          </widget>
-         </item>
-         <item row="11" column="0">
-          <widget class="QLabel" name="label_66">
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>TS 4</string>
-           </property>
-          </widget>
-         </item>
-         <item row="10" column="0">
-          <widget class="QLabel" name="label_65">
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>TS 3</string>
-           </property>
-          </widget>
-         </item>
-         <item row="8" column="0">
-          <widget class="QLabel" name="label_26">
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>TS 1</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="6">
-          <widget class="PyDMLabel" name="PyDMLabel_63">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PACT03</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="4">
-          <widget class="PyDMLabel" name="PyDMLabel_101">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PDES01</string>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="8">
-          <widget class="QLabel" name="label_31">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>1</horstretch>
-             <verstretch>1</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>ASET</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="6">
-          <widget class="PyDMLabel" name="PyDMLabel_65">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PACT05</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="label_20">
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>TS 1</string>
-           </property>
-          </widget>
-         </item>
-         <item row="8" column="2">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_39">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:T1:AREQ_OFFSET</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="4">
-          <widget class="PyDMLabel" name="PyDMLabel_154">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PDES04</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="8">
-          <widget class="PyDMLabel" name="PyDMLabel_76">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PSET03</string>
-           </property>
-          </widget>
-         </item>
-         <item row="13" column="4">
-          <widget class="PyDMLabel" name="PyDMLabel_166">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:ADES06</string>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="2">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_57">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:T5:PDES_OFFSET</string>
-           </property>
-          </widget>
-         </item>
-         <item row="13" column="6">
-          <widget class="PyDMLabel" name="PyDMLabel_72">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AACT06</string>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="4">
-          <widget class="PyDMLabel" name="PyDMLabel_156">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PDES06</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="8">
-          <widget class="PyDMLabel" name="PyDMLabel_77">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PSET02</string>
-           </property>
-          </widget>
-         </item>
-         <item row="9" column="11">
-          <widget class="PyDMLabel" name="PyDMLabel_106">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:BVOLT_PK_SLOW02</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="2">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_55">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:T3:PDES_OFFSET</string>
-           </property>
-          </widget>
-         </item>
-         <item row="13" column="11">
-          <widget class="PyDMLabel" name="PyDMLabel_110">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:BVOLT_PK_SLOW06</string>
-           </property>
-          </widget>
-         </item>
-         <item row="13" column="0">
-          <widget class="QLabel" name="label_68">
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>TS 6</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="10">
-          <widget class="QLabel" name="label_32">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>1</horstretch>
-             <verstretch>1</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>PREF</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="6">
-          <widget class="PyDMLabel" name="PyDMLabel_64">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PACT04</string>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="2">
-          <widget class="QLabel" name="label_63">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>1</horstretch>
-             <verstretch>1</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>AOFF</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="11" column="11">
-          <widget class="PyDMLabel" name="PyDMLabel_108">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:BVOLT_PK_SLOW04</string>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="8">
-          <widget class="PyDMLabel" name="PyDMLabel_74">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PSET05</string>
-           </property>
-          </widget>
-         </item>
-         <item row="12" column="0">
-          <widget class="QLabel" name="label_67">
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>TS 5</string>
-           </property>
-          </widget>
-         </item>
          <item row="2" column="10">
           <widget class="PyDMLabel" name="PyDMLabel_89">
            <property name="toolTip">
@@ -955,154 +73,6 @@
            </property>
            <property name="channel" stdset="0">
             <string>ca://${DEVICE}:PREF02</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="8">
-          <widget class="QLabel" name="label_30">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>1</horstretch>
-             <verstretch>1</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>PSET</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="6">
-          <widget class="PyDMLabel" name="PyDMLabel_66">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PACT06</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="10">
-          <widget class="PyDMLabel" name="PyDMLabel_85">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PREF01</string>
-           </property>
-          </widget>
-         </item>
-         <item row="11" column="4">
-          <widget class="PyDMLabel" name="PyDMLabel_164">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:ADES04</string>
-           </property>
-          </widget>
-         </item>
-         <item row="10" column="2">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_60">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:T3:AREQ_OFFSET</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="2">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_54">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:T2:PDES_OFFSET</string>
-           </property>
-          </widget>
-         </item>
-         <item row="10" column="8">
-          <widget class="PyDMLabel" name="PyDMLabel_82">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:ASET03</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QLabel" name="label_54">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>1</horstretch>
-             <verstretch>1</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>PREQ</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="8">
-          <widget class="PyDMLabel" name="PyDMLabel_78">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PSET06</string>
-           </property>
-          </widget>
-         </item>
-         <item row="8" column="4">
-          <widget class="PyDMLabel" name="PyDMLabel_104">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:ADES01</string>
            </property>
           </widget>
          </item>
@@ -1119,8 +89,8 @@
            </property>
           </widget>
          </item>
-         <item row="4" column="8">
-          <widget class="PyDMLabel" name="PyDMLabel_75">
+         <item row="2" column="2">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_54">
            <property name="toolTip">
             <string/>
            </property>
@@ -1128,12 +98,12 @@
             <set>Qt::AlignCenter</set>
            </property>
            <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PSET04</string>
+            <string>ca://${DEVICE}:T2:PDES_OFFSET</string>
            </property>
           </widget>
          </item>
-         <item row="13" column="8">
-          <widget class="PyDMLabel" name="PyDMLabel_84">
+         <item row="2" column="8">
+          <widget class="PyDMLabel" name="PyDMLabel_77">
            <property name="toolTip">
             <string/>
            </property>
@@ -1141,12 +111,12 @@
             <set>Qt::AlignCenter</set>
            </property>
            <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:ASET06</string>
+            <string>ca://${DEVICE}:PSET02</string>
            </property>
           </widget>
          </item>
-         <item row="9" column="10">
-          <widget class="PyDMLabel" name="PyDMLabel_95">
+         <item row="1" column="10">
+          <widget class="PyDMLabel" name="PyDMLabel_85">
            <property name="toolTip">
             <string/>
            </property>
@@ -1154,12 +124,12 @@
             <set>Qt::AlignCenter</set>
            </property>
            <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AREF02</string>
+            <string>ca://${DEVICE}:PREF01</string>
            </property>
           </widget>
          </item>
-         <item row="5" column="10">
-          <widget class="PyDMLabel" name="PyDMLabel_86">
+         <item row="13" column="6">
+          <widget class="PyDMLabel" name="PyDMLabel_72">
            <property name="toolTip">
             <string/>
            </property>
@@ -1167,12 +137,12 @@
             <set>Qt::AlignCenter</set>
            </property>
            <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PREF05</string>
+            <string>ca://${DEVICE}:AACT06</string>
            </property>
           </widget>
          </item>
-         <item row="4" column="2">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_56">
+         <item row="5" column="8">
+          <widget class="PyDMLabel" name="PyDMLabel_74">
            <property name="toolTip">
             <string/>
            </property>
@@ -1180,46 +150,7 @@
             <set>Qt::AlignCenter</set>
            </property>
            <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:T4:PDES_OFFSET</string>
-           </property>
-          </widget>
-         </item>
-         <item row="9" column="6">
-          <widget class="PyDMLabel" name="PyDMLabel_71">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AACT02</string>
-           </property>
-          </widget>
-         </item>
-         <item row="10" column="6">
-          <widget class="PyDMLabel" name="PyDMLabel_70">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AACT03</string>
-           </property>
-          </widget>
-         </item>
-         <item row="11" column="8">
-          <widget class="PyDMLabel" name="PyDMLabel_81">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:ASET04</string>
+            <string>ca://${DEVICE}:PSET05</string>
            </property>
           </widget>
          </item>
@@ -1245,8 +176,8 @@
            </property>
           </widget>
          </item>
-         <item row="6" column="2">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_58">
+         <item row="10" column="2">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_60">
            <property name="toolTip">
             <string/>
            </property>
@@ -1254,25 +185,12 @@
             <set>Qt::AlignCenter</set>
            </property>
            <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:T6:PDES_OFFSET</string>
+            <string>ca://${DEVICE}:T3:AREQ_OFFSET</string>
            </property>
           </widget>
          </item>
-         <item row="6" column="0">
-          <widget class="QLabel" name="label_25">
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>TS 6</string>
-           </property>
-          </widget>
-         </item>
-         <item row="9" column="4">
-          <widget class="PyDMLabel" name="PyDMLabel_162">
+         <item row="11" column="8">
+          <widget class="PyDMLabel" name="PyDMLabel_81">
            <property name="toolTip">
             <string/>
            </property>
@@ -1280,18 +198,12 @@
             <set>Qt::AlignCenter</set>
            </property>
            <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:ADES02</string>
+            <string>ca://${DEVICE}:ASET04</string>
            </property>
           </widget>
          </item>
-         <item row="8" column="11">
-          <widget class="PyDMLabel" name="PyDMLabel_105">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
+         <item row="10" column="8">
+          <widget class="PyDMLabel" name="PyDMLabel_82">
            <property name="toolTip">
             <string/>
            </property>
@@ -1299,124 +211,7 @@
             <set>Qt::AlignCenter</set>
            </property>
            <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:BVOLT_PK_SLOW01</string>
-           </property>
-          </widget>
-         </item>
-         <item row="9" column="2">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_59">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:T2:AREQ_OFFSET</string>
-           </property>
-          </widget>
-         </item>
-         <item row="12" column="6">
-          <widget class="PyDMLabel" name="PyDMLabel_68">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AACT05</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="4">
-          <widget class="PyDMLabel" name="PyDMLabel_152">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PDES02</string>
-           </property>
-          </widget>
-         </item>
-         <item row="10" column="10">
-          <widget class="PyDMLabel" name="PyDMLabel_94">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AREF03</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="8">
-          <widget class="PyDMLabel" name="PyDMLabel_73">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PSET01</string>
-           </property>
-          </widget>
-         </item>
-         <item row="13" column="2">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_63">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:T6:AREQ_OFFSET</string>
-           </property>
-          </widget>
-         </item>
-         <item row="12" column="8">
-          <widget class="PyDMLabel" name="PyDMLabel_80">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:ASET05</string>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="10">
-          <widget class="PyDMLabel" name="PyDMLabel_90">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PREF06</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="6">
-          <widget class="PyDMLabel" name="PyDMLabel_61">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PACT01</string>
+            <string>ca://${DEVICE}:ASET03</string>
            </property>
           </widget>
          </item>
@@ -1439,6 +234,58 @@
            </property>
           </widget>
          </item>
+         <item row="2" column="6">
+          <widget class="PyDMLabel" name="PyDMLabel_62">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PACT02</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="8">
+          <widget class="PyDMLabel" name="PyDMLabel_78">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PSET06</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="4">
+          <widget class="PyDMLabel" name="PyDMLabel_156">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PDES06</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="8">
+          <widget class="PyDMLabel" name="PyDMLabel_73">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PSET01</string>
+           </property>
+          </widget>
+         </item>
          <item row="12" column="4">
           <widget class="PyDMLabel" name="PyDMLabel_165">
            <property name="toolTip">
@@ -1449,6 +296,58 @@
            </property>
            <property name="channel" stdset="0">
             <string>ca://${DEVICE}:ADES05</string>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="0">
+          <widget class="QLabel" name="label_27">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>TS 2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="4">
+          <widget class="PyDMLabel" name="PyDMLabel_162">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:ADES02</string>
+           </property>
+          </widget>
+         </item>
+         <item row="11" column="4">
+          <widget class="PyDMLabel" name="PyDMLabel_164">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:ADES04</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="4">
+          <widget class="PyDMLabel" name="PyDMLabel_152">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PDES02</string>
            </property>
           </widget>
          </item>
@@ -1465,72 +364,34 @@
            </property>
           </widget>
          </item>
-         <item row="12" column="2">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_62">
-           <property name="toolTip">
-            <string/>
+         <item row="8" column="0">
+          <widget class="QLabel" name="label_26">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
            </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:T5:AREQ_OFFSET</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1" rowspan="6">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_41">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PDES</string>
+           <property name="text">
+            <string>TS 1</string>
            </property>
           </widget>
          </item>
-         <item row="11" column="10">
-          <widget class="PyDMLabel" name="PyDMLabel_93">
-           <property name="toolTip">
-            <string/>
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_21">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
            </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AREF04</string>
-           </property>
-          </widget>
-         </item>
-         <item row="12" column="11">
-          <widget class="PyDMLabel" name="PyDMLabel_109">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:BVOLT_PK_SLOW05</string>
+           <property name="text">
+            <string>TS 2</string>
            </property>
           </widget>
          </item>
-         <item row="1" column="2">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_37">
+         <item row="9" column="8">
+          <widget class="PyDMLabel" name="PyDMLabel_83">
            <property name="toolTip">
             <string/>
            </property>
@@ -1538,7 +399,72 @@
             <set>Qt::AlignCenter</set>
            </property>
            <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:T1:PDES_OFFSET</string>
+            <string>ca://${DEVICE}:ASET02</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="8">
+          <widget class="PyDMLabel" name="PyDMLabel_75">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PSET04</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="6">
+          <widget class="PyDMLabel" name="PyDMLabel_66">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PACT06</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="2">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_56">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:T4:PDES_OFFSET</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="10">
+          <widget class="PyDMLabel" name="PyDMLabel_86">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PREF05</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="6">
+          <widget class="PyDMLabel" name="PyDMLabel_63">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PACT03</string>
            </property>
           </widget>
          </item>
@@ -1586,8 +512,60 @@
            </property>
           </widget>
          </item>
-         <item row="7" column="1">
-          <widget class="QLabel" name="label_70">
+         <item row="3" column="2">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_55">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:T3:PDES_OFFSET</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="label_22">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>TS 3</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="label_24">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>TS 5</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="4">
+          <widget class="PyDMLabel" name="PyDMLabel_154">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PDES04</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="6">
+          <widget class="QLabel" name="label_28">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
              <horstretch>1</horstretch>
@@ -1601,54 +579,15 @@
             </font>
            </property>
            <property name="text">
-            <string>AREQ</string>
+            <string>PACT</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignCenter</set>
            </property>
           </widget>
          </item>
-         <item row="5" column="4">
-          <widget class="PyDMLabel" name="PyDMLabel_155">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PDES05</string>
-           </property>
-          </widget>
-         </item>
-         <item row="8" column="10">
-          <widget class="PyDMLabel" name="PyDMLabel_91">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AREF01</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="label_21">
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>TS 2</string>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="11">
-          <widget class="QLabel" name="label_71">
+         <item row="0" column="10">
+          <widget class="QLabel" name="label_32">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
              <horstretch>1</horstretch>
@@ -1662,10 +601,23 @@
             </font>
            </property>
            <property name="text">
-            <string>Beam Peak Voltage (kV)</string>
+            <string>PREF</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="10">
+          <widget class="PyDMLabel" name="PyDMLabel_87">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PREF04</string>
            </property>
           </widget>
          </item>
@@ -1682,8 +634,8 @@
            </property>
           </widget>
          </item>
-         <item row="9" column="0">
-          <widget class="QLabel" name="label_27">
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_20">
            <property name="font">
             <font>
              <weight>75</weight>
@@ -1691,12 +643,12 @@
             </font>
            </property>
            <property name="text">
-            <string>TS 2</string>
+            <string>TS 1</string>
            </property>
           </widget>
          </item>
-         <item row="3" column="4">
-          <widget class="PyDMLabel" name="PyDMLabel_153">
+         <item row="5" column="2">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_57">
            <property name="toolTip">
             <string/>
            </property>
@@ -1704,7 +656,123 @@
             <set>Qt::AlignCenter</set>
            </property>
            <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PDES03</string>
+            <string>ca://${DEVICE}:T5:PDES_OFFSET</string>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="11">
+          <widget class="PyDMLabel" name="PyDMLabel_106">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:BVOLT_PK_SLOW02</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="10">
+          <widget class="PyDMLabel" name="PyDMLabel_91">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AREF01</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="2">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_58">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:T6:PDES_OFFSET</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_37">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:T1:PDES_OFFSET</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="label_25">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>TS 6</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="6">
+          <widget class="PyDMLabel" name="PyDMLabel_64">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PACT04</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="2">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_39">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:T1:AREQ_OFFSET</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1" rowspan="6">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_41">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PDES</string>
            </property>
           </widget>
          </item>
@@ -1721,14 +789,8 @@
            </property>
           </widget>
          </item>
-         <item row="10" column="11">
-          <widget class="PyDMLabel" name="PyDMLabel_107">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
+         <item row="10" column="6">
+          <widget class="PyDMLabel" name="PyDMLabel_70">
            <property name="toolTip">
             <string/>
            </property>
@@ -1736,7 +798,7 @@
             <set>Qt::AlignCenter</set>
            </property>
            <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:BVOLT_PK_SLOW03</string>
+            <string>ca://${DEVICE}:AACT03</string>
            </property>
           </widget>
          </item>
@@ -1762,8 +824,8 @@
            </property>
           </widget>
          </item>
-         <item row="11" column="2">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_61">
+         <item row="1" column="6">
+          <widget class="PyDMLabel" name="PyDMLabel_61">
            <property name="toolTip">
             <string/>
            </property>
@@ -1771,12 +833,12 @@
             <set>Qt::AlignCenter</set>
            </property>
            <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:T4:AREQ_OFFSET</string>
+            <string>ca://${DEVICE}:PACT01</string>
            </property>
           </widget>
          </item>
-         <item row="9" column="8">
-          <widget class="PyDMLabel" name="PyDMLabel_83">
+         <item row="5" column="6">
+          <widget class="PyDMLabel" name="PyDMLabel_65">
            <property name="toolTip">
             <string/>
            </property>
@@ -1784,7 +846,221 @@
             <set>Qt::AlignCenter</set>
            </property>
            <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:ASET02</string>
+            <string>ca://${DEVICE}:PACT05</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="label_23">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>TS 4</string>
+           </property>
+          </widget>
+         </item>
+         <item row="11" column="10">
+          <widget class="PyDMLabel" name="PyDMLabel_93">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AREF04</string>
+           </property>
+          </widget>
+         </item>
+         <item row="13" column="10">
+          <widget class="PyDMLabel" name="PyDMLabel_96">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AREF06</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="11">
+          <widget class="QLabel" name="label_71">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>1</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Beam Peak Voltage (kV)</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="13" column="8">
+          <widget class="PyDMLabel" name="PyDMLabel_84">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:ASET06</string>
+           </property>
+          </widget>
+         </item>
+         <item row="13" column="11">
+          <widget class="PyDMLabel" name="PyDMLabel_110">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:BVOLT_PK_SLOW06</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLabel" name="label_54">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>1</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>PREQ</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="11" column="11">
+          <widget class="PyDMLabel" name="PyDMLabel_108">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:BVOLT_PK_SLOW04</string>
+           </property>
+          </widget>
+         </item>
+         <item row="13" column="2">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_63">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:T6:AREQ_OFFSET</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="1">
+          <widget class="QLabel" name="label_70">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>1</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>AREQ</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="4">
+          <widget class="PyDMLabel" name="PyDMLabel_153">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PDES03</string>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="10">
+          <widget class="PyDMLabel" name="PyDMLabel_95">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AREF02</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="11">
+          <widget class="PyDMLabel" name="PyDMLabel_105">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:BVOLT_PK_SLOW01</string>
            </property>
           </widget>
          </item>
@@ -1798,6 +1074,366 @@
            </property>
            <property name="channel" stdset="0">
             <string>ca://${DEVICE}:ASET01</string>
+           </property>
+          </widget>
+         </item>
+         <item row="12" column="0">
+          <widget class="QLabel" name="label_67">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>TS 5</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="4">
+          <widget class="PyDMLabel" name="PyDMLabel_155">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PDES05</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="2">
+          <widget class="QLabel" name="label_63">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>1</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>AOFF</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="12" column="11">
+          <widget class="PyDMLabel" name="PyDMLabel_109">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:BVOLT_PK_SLOW05</string>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="6">
+          <widget class="PyDMLabel" name="PyDMLabel_71">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AACT02</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="10">
+          <widget class="QLabel" name="label_33">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>1</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>AREF</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="10" column="11">
+          <widget class="PyDMLabel" name="PyDMLabel_107">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:BVOLT_PK_SLOW03</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="8">
+          <widget class="QLabel" name="label_31">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>1</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>ASET</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="13" column="0">
+          <widget class="QLabel" name="label_68">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>TS 6</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="8">
+          <widget class="PyDMLabel" name="PyDMLabel_76">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PSET03</string>
+           </property>
+          </widget>
+         </item>
+         <item row="10" column="10">
+          <widget class="PyDMLabel" name="PyDMLabel_94">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AREF03</string>
+           </property>
+          </widget>
+         </item>
+         <item row="10" column="4">
+          <widget class="PyDMLabel" name="PyDMLabel_163">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:ADES03</string>
+           </property>
+          </widget>
+         </item>
+         <item row="12" column="2">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_62">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:T5:AREQ_OFFSET</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="10">
+          <widget class="PyDMLabel" name="PyDMLabel_90">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PREF06</string>
+           </property>
+          </widget>
+         </item>
+         <item row="10" column="0">
+          <widget class="QLabel" name="label_65">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>TS 3</string>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="2">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_59">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:T2:AREQ_OFFSET</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="8">
+          <widget class="QLabel" name="label_30">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>1</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>PSET</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="4">
+          <widget class="PyDMLabel" name="PyDMLabel_104">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:ADES01</string>
+           </property>
+          </widget>
+         </item>
+         <item row="12" column="8">
+          <widget class="PyDMLabel" name="PyDMLabel_80">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:ASET05</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="4">
+          <widget class="PyDMLabel" name="PyDMLabel_101">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PDES01</string>
+           </property>
+          </widget>
+         </item>
+         <item row="11" column="2">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_61">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:T4:AREQ_OFFSET</string>
+           </property>
+          </widget>
+         </item>
+         <item row="11" column="0">
+          <widget class="QLabel" name="label_66">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>TS 4</string>
+           </property>
+          </widget>
+         </item>
+         <item row="13" column="4">
+          <widget class="PyDMLabel" name="PyDMLabel_166">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:ADES06</string>
+           </property>
+          </widget>
+         </item>
+         <item row="12" column="6">
+          <widget class="PyDMLabel" name="PyDMLabel_68">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AACT05</string>
            </property>
           </widget>
          </item>
@@ -4232,6 +3868,393 @@ Conversion Factor(kV/Count)</string>
           </size>
          </property>
         </spacer>
+       </item>
+       <item row="0" column="2" rowspan="5">
+        <layout class="QGridLayout" name="gridLayout_9" columnstretch="0,0">
+         <item row="5" column="0">
+          <widget class="PyDMWaveformPlot" name="PyDMWaveformPlot_6">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>1</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="showXGrid">
+            <bool>true</bool>
+           </property>
+           <property name="showYGrid">
+            <bool>true</bool>
+           </property>
+           <property name="showLegend">
+            <bool>true</bool>
+           </property>
+           <property name="curves">
+            <stringlist>
+             <string>{&quot;y_channel&quot;: &quot;ca://${DEVICE}:ICPXWND1&quot;, &quot;x_channel&quot;: null, &quot;name&quot;: &quot;I&quot;, &quot;color&quot;: &quot;#ff557f&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
+             <string>{&quot;y_channel&quot;: &quot;ca://${DEVICE}:QCPXWND1&quot;, &quot;x_channel&quot;: null, &quot;name&quot;: &quot;Q&quot;, &quot;color&quot;: &quot;#5500ff&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
+            </stringlist>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <layout class="QHBoxLayout" name="horizontalLayout_3">
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_57">
+             <property name="text">
+              <string>Feedback Complex Window</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton_2">
+             <property name="minimumSize">
+              <size>
+               <width>100</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>100</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="text">
+              <string>Define</string>
+             </property>
+             <property name="filenames" stdset="0">
+              <stringlist>
+               <string>define_complex_window.py</string>
+              </stringlist>
+             </property>
+             <property name="macros" stdset="0">
+              <stringlist>
+               <string>{&quot;TITLE&quot;:&quot;Baseband Complex Window&quot;, &quot;R&quot;:&quot;BL&quot;, &quot;N&quot;:&quot;&quot;}</string>
+              </stringlist>
+             </property>
+             <property name="openInNewWindow" stdset="0">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="8" column="0">
+          <widget class="PyDMWaveformPlot" name="PyDMWaveformPlot_7">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>1</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="showXGrid">
+            <bool>true</bool>
+           </property>
+           <property name="showYGrid">
+            <bool>true</bool>
+           </property>
+           <property name="showLegend">
+            <bool>true</bool>
+           </property>
+           <property name="curves">
+            <stringlist>
+             <string>{&quot;y_channel&quot;: &quot;ca://${DEVICE}:ICPXWND2&quot;, &quot;x_channel&quot;: null, &quot;name&quot;: &quot;I&quot;, &quot;color&quot;: &quot;#ff557f&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
+             <string>{&quot;y_channel&quot;: &quot;ca://${DEVICE}:QCPXWND2&quot;, &quot;x_channel&quot;: null, &quot;name&quot;: &quot;Q&quot;, &quot;color&quot;: &quot;#5500ff&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
+            </stringlist>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="text">
+            <string>IQ Waveforms</string>
+           </property>
+           <property name="filenames" stdset="0">
+            <stringlist>
+             <string>iqwaveform.ui</string>
+             <string>iqwaveform.ui</string>
+             <string>iqwaveform.ui</string>
+             <string>iqwaveform.ui</string>
+             <string>iqwaveform.ui</string>
+             <string>iqwaveform.ui</string>
+             <string>iqwaveform.ui</string>
+             <string>iqwaveform.ui</string>
+             <string>iqwaveform.ui</string>
+             <string>iqwaveform.ui</string>
+            </stringlist>
+           </property>
+           <property name="titles" stdset="0">
+            <stringlist>
+             <string>IQ-Waveform - DwnCon:RF_IN_1</string>
+             <string>IQ-Waveform - DwnCon:RF_IN_2</string>
+             <string>IQ-Waveform - DwnCon:RF_IN_3</string>
+             <string>IQ-Waveform - DwnCon:RF_IN_4</string>
+             <string>IQ-Waveform - DwnCon:RF_IN_5</string>
+             <string>IQ-Waveform - DwnCon:RF_IN_6</string>
+             <string>IQ-Waveform - UpCon:RF_IN_1</string>
+             <string>IQ-Waveform - UpCon:RF_IN_2</string>
+             <string>IQ-Waveform - UpCon:RF_IN_3</string>
+             <string>IQ-Waveform - UpCon:RF_OUT_MON</string>
+            </stringlist>
+           </property>
+           <property name="macros" stdset="0">
+            <stringlist>
+             <string>{&quot;N&quot;:&quot;1&quot;}</string>
+             <string>{&quot;N&quot;:&quot;0&quot;}</string>
+             <string>{&quot;N&quot;:&quot;3&quot;}</string>
+             <string>{&quot;N&quot;:&quot;2&quot;}</string>
+             <string>{&quot;N&quot;:&quot;5&quot;}</string>
+             <string>{&quot;N&quot;:&quot;4&quot;}</string>
+             <string>{&quot;N&quot;:&quot;7&quot;}</string>
+             <string>{&quot;N&quot;:&quot;6&quot;}</string>
+             <string>{&quot;N&quot;:&quot;8&quot;}</string>
+             <string>{&quot;N&quot;:&quot;9&quot;}</string>
+            </stringlist>
+           </property>
+           <property name="openInNewWindow" stdset="0">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="PyDMWaveformPlot" name="PyDMWaveformPlot_5">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>1</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="showXGrid">
+            <bool>true</bool>
+           </property>
+           <property name="showYGrid">
+            <bool>true</bool>
+           </property>
+           <property name="showLegend">
+            <bool>true</bool>
+           </property>
+           <property name="curves">
+            <stringlist>
+             <string>{&quot;y_channel&quot;: &quot;ca://${DEVICE}:ICPXWND0&quot;, &quot;x_channel&quot;: null, &quot;name&quot;: &quot;I&quot;, &quot;color&quot;: &quot;#ff557f&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
+             <string>{&quot;y_channel&quot;: &quot;ca://${DEVICE}:QCPXWND0&quot;, &quot;x_channel&quot;: null, &quot;name&quot;: &quot;Q&quot;, &quot;color&quot;: &quot;#5500ff&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
+            </stringlist>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="0">
+          <layout class="QHBoxLayout" name="horizontalLayout_5">
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_59">
+             <property name="text">
+              <string>Diagnostics Complex Window 2</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton_4">
+             <property name="minimumSize">
+              <size>
+               <width>100</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>100</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="text">
+              <string>Define</string>
+             </property>
+             <property name="filenames" stdset="0">
+              <stringlist>
+               <string>define_complex_window.py</string>
+              </stringlist>
+             </property>
+             <property name="macros" stdset="0">
+              <stringlist>
+               <string>{&quot;TITLE&quot;:&quot;Baseband Complex Window&quot;, &quot;R&quot;:&quot;BL&quot;, &quot;N&quot;:&quot;&quot;}</string>
+              </stringlist>
+             </property>
+             <property name="openInNewWindow" stdset="0">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="4" column="0">
+          <layout class="QHBoxLayout" name="horizontalLayout_4">
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_58">
+             <property name="text">
+              <string>Diagnostics Complex Window 1</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton_3">
+             <property name="minimumSize">
+              <size>
+               <width>100</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>100</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="text">
+              <string>Define</string>
+             </property>
+             <property name="filenames" stdset="0">
+              <stringlist>
+               <string>define_complex_window.py</string>
+              </stringlist>
+             </property>
+             <property name="macros" stdset="0">
+              <stringlist>
+               <string>{&quot;TITLE&quot;:&quot;Baseband Complex Window&quot;, &quot;R&quot;:&quot;BL&quot;, &quot;N&quot;:&quot;&quot;}</string>
+              </stringlist>
+             </property>
+             <property name="openInNewWindow" stdset="0">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="1" column="1">
+          <layout class="QHBoxLayout" name="horizontalLayout_2">
+           <item>
+            <widget class="QLabel" name="label_53">
+             <property name="text">
+              <string>Baseband I/Q Drive Waveforms</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton_5">
+             <property name="minimumSize">
+              <size>
+               <width>100</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>100</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="text">
+              <string>Define</string>
+             </property>
+             <property name="filenames" stdset="0">
+              <stringlist>
+               <string>define_complex_window.py</string>
+              </stringlist>
+             </property>
+             <property name="macros" stdset="0">
+              <stringlist>
+               <string>{&quot;TITLE&quot;:&quot;Baseband Complex Window&quot;, &quot;R&quot;:&quot;BL&quot;, &quot;N&quot;:&quot;&quot;}</string>
+              </stringlist>
+             </property>
+             <property name="openInNewWindow" stdset="0">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="2" column="1">
+          <widget class="PyDMWaveformPlot" name="PyDMWaveformPlot">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>1</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="showXGrid">
+            <bool>true</bool>
+           </property>
+           <property name="showYGrid">
+            <bool>true</bool>
+           </property>
+           <property name="showLegend">
+            <bool>true</bool>
+           </property>
+           <property name="curves">
+            <stringlist>
+             <string>{&quot;y_channel&quot;: &quot;ca://${DEVICE}:IBL&quot;, &quot;x_channel&quot;: null, &quot;name&quot;: &quot;I&quot;, &quot;color&quot;: &quot;#ff557f&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
+             <string>{&quot;y_channel&quot;: &quot;ca://${DEVICE}:QBL&quot;, &quot;x_channel&quot;: null, &quot;name&quot;: &quot;Q&quot;, &quot;color&quot;: &quot;#5500ff&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
+            </stringlist>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="1">
+          <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton_6">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="text">
+            <string>Feddback Complex Window</string>
+           </property>
+           <property name="filenames" stdset="0">
+            <stringlist>
+             <string>hls_complex_window.ui</string>
+            </stringlist>
+           </property>
+           <property name="macros" stdset="0">
+            <stringlist>
+             <string>{&quot;TITLE&quot;:&quot;Feedback Complex Window&quot;, &quot;R&quot;:&quot;CPXWND&quot;, &quot;N&quot;:&quot;0&quot;}</string>
+            </stringlist>
+           </property>
+           <property name="openInNewWindow" stdset="0">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
       </layout>
      </widget>

--- a/llrf_hls.ui
+++ b/llrf_hls.ui
@@ -37,7 +37,7 @@
         <x>0</x>
         <y>0</y>
         <width>1922</width>
-        <height>1314</height>
+        <height>1349</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout_8">
@@ -1441,8 +1441,21 @@
        </item>
        <item row="2" column="0">
         <layout class="QGridLayout" name="gridLayout">
-         <item row="13" column="5">
-          <widget class="PyDMLabel" name="PyDMLabel_17">
+         <item row="14" column="0">
+          <widget class="QLabel" name="label_10">
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>RF_OUT_MON</string>
+           </property>
+          </widget>
+         </item>
+         <item row="13" column="8">
+          <widget class="PyDMLabel" name="PyDMLabel_47">
            <property name="toolTip">
             <string/>
            </property>
@@ -1450,12 +1463,141 @@
             <set>Qt::AlignCenter</set>
            </property>
            <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AMPL_W0CH8</string>
+            <string>ca://${DEVICE}:PHASE_W2CH8</string>
            </property>
           </widget>
          </item>
-         <item row="2" column="6">
-          <widget class="QLabel" name="label_16">
+         <item row="5" column="4">
+          <widget class="PyDMLabel" name="PyDMLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>1</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PHASE_W0CH0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="14" column="4">
+          <widget class="PyDMLabel" name="PyDMLabel_10">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PHASE_W0CH9</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="4">
+          <widget class="PyDMLabel" name="PyDMLabel_6">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PHASE_W0CH5</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>1</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:REFWGT0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="4">
+          <widget class="PyDMLabel" name="PyDMLabel_2">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PHASE_W0CH1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="7">
+          <widget class="PyDMLabel" name="PyDMLabel_34">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AMPL_W1CH3</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="2">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_14">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:FBWGT2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="13" column="0">
+          <widget class="QLabel" name="label_9">
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>RF_IN_3</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="3">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_23">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:POC1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="4">
+          <widget class="QLabel" name="label_14">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
              <horstretch>1</horstretch>
@@ -1476,34 +1618,112 @@
            </property>
           </widget>
          </item>
-         <item row="3" column="0">
-          <widget class="QLabel" name="label_60">
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
+         <item row="8" column="7">
+          <widget class="PyDMLabel" name="PyDMLabel_35">
+           <property name="toolTip">
+            <string/>
            </property>
-           <property name="text">
-            <string>Down Converter</string>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
            </property>
-          </widget>
-         </item>
-         <item row="13" column="0">
-          <widget class="QLabel" name="label_9">
-           <property name="font">
-            <font>
-             <weight>50</weight>
-             <bold>false</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>RF_IN_3</string>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AMPL_W1CH5</string>
            </property>
           </widget>
          </item>
-         <item row="2" column="7">
-          <widget class="QLabel" name="label_18">
+         <item row="4" column="8">
+          <widget class="PyDMLabel" name="PyDMLabel_43">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PHASE_W2CH1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="6">
+          <widget class="PyDMLabel" name="PyDMLabel_30">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PHASE_W1CH4</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_4">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:REFWGT3</string>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="2">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_12">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:FBWGT4</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="9">
+          <widget class="PyDMLabel" name="PyDMLabel_53">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AMPL_W2CH1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="3">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_24">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:POC2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="12" column="1">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_7">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:REFWGT6</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="2">
+          <widget class="QLabel" name="label_12">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
              <horstretch>1</horstretch>
@@ -1517,36 +1737,209 @@
             </font>
            </property>
            <property name="text">
-            <string>Amplitude</string>
+            <string>Feedback Weight</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignCenter</set>
            </property>
           </widget>
          </item>
-         <item row="0" column="8" colspan="2">
-          <widget class="QLabel" name="label_52">
+         <item row="11" column="9">
+          <widget class="PyDMLabel" name="PyDMLabel_52">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AMPL_W2CH7</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="6">
+          <widget class="PyDMLabel" name="PyDMLabel_21">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>1</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PHASE_W1CH0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="8">
+          <widget class="PyDMLabel" name="PyDMLabel_46">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PHASE_W2CH2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="7">
+          <widget class="PyDMLabel" name="PyDMLabel_40">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AMPL_W1CH4</string>
+           </property>
+          </widget>
+         </item>
+         <item row="11" column="8">
+          <widget class="PyDMLabel" name="PyDMLabel_42">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PHASE_W2CH7</string>
+           </property>
+          </widget>
+         </item>
+         <item row="12" column="5">
+          <widget class="PyDMLabel" name="PyDMLabel_19">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AMPL_W0CH6</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="4">
+          <widget class="PyDMLabel" name="PyDMLabel_3">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PHASE_W0CH2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="5">
+          <widget class="PyDMLabel" name="PyDMLabel_16">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AMPL_W0CH2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="label">
            <property name="font">
             <font>
-             <pointsize>9</pointsize>
-             <weight>75</weight>
-             <bold>true</bold>
-             <underline>true</underline>
+             <weight>50</weight>
+             <bold>false</bold>
             </font>
            </property>
-           <property name="styleSheet">
-            <string notr="true">QLabel{background-color: #ffff7f;}</string>
+           <property name="text">
+            <string>RF_IN_2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="13" column="5">
+          <widget class="PyDMLabel" name="PyDMLabel_17">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AMPL_W0CH8</string>
+           </property>
+          </widget>
+         </item>
+         <item row="11" column="7">
+          <widget class="PyDMLabel" name="PyDMLabel_32">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AMPL_W1CH7</string>
+           </property>
+          </widget>
+         </item>
+         <item row="14" column="3">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_28">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:POC9</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="7">
+          <widget class="PyDMLabel" name="PyDMLabel_36">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AMPL_W1CH2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="label_2">
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <bold>false</bold>
+            </font>
            </property>
            <property name="text">
-            <string>Average Window 2 for Diagnostics</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignHCenter|Qt::AlignTop</set>
+            <string>RF_IN_1</string>
            </property>
           </widget>
          </item>
-         <item row="14" column="9">
-          <widget class="PyDMLabel" name="PyDMLabel_58">
+         <item row="5" column="5">
+          <widget class="PyDMLabel" name="PyDMLabel_11">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>1</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
+           </property>
            <property name="toolTip">
             <string/>
            </property>
@@ -1554,12 +1947,12 @@
             <set>Qt::AlignCenter</set>
            </property>
            <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AMPL_W2CH9</string>
+            <string>ca://${DEVICE}:AMPL_W0CH0</string>
            </property>
           </widget>
          </item>
-         <item row="13" column="2">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_16">
+         <item row="6" column="4">
+          <widget class="PyDMLabel" name="PyDMLabel_4">
            <property name="toolTip">
             <string/>
            </property>
@@ -1567,7 +1960,46 @@
             <set>Qt::AlignCenter</set>
            </property>
            <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:FBWGT8</string>
+            <string>ca://${DEVICE}:PHASE_W0CH3</string>
+           </property>
+          </widget>
+         </item>
+         <item row="11" column="0">
+          <widget class="QLabel" name="label_8">
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>RF_IN_1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="13" column="4">
+          <widget class="PyDMLabel" name="PyDMLabel_9">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PHASE_W0CH8</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="3">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_29">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:POC5</string>
            </property>
           </widget>
          </item>
@@ -1593,8 +2025,8 @@
            </property>
           </widget>
          </item>
-         <item row="13" column="7">
-          <widget class="PyDMLabel" name="PyDMLabel_37">
+         <item row="6" column="5">
+          <widget class="PyDMLabel" name="PyDMLabel_14">
            <property name="toolTip">
             <string/>
            </property>
@@ -1602,12 +2034,18 @@
             <set>Qt::AlignCenter</set>
            </property>
            <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AMPL_W1CH8</string>
+            <string>ca://${DEVICE}:AMPL_W0CH3</string>
            </property>
           </widget>
          </item>
-         <item row="14" column="5">
-          <widget class="PyDMLabel" name="PyDMLabel_18">
+         <item row="5" column="7">
+          <widget class="PyDMLabel" name="PyDMLabel_31">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>1</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
+           </property>
            <property name="toolTip">
             <string/>
            </property>
@@ -1615,7 +2053,7 @@
             <set>Qt::AlignCenter</set>
            </property>
            <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AMPL_W0CH9</string>
+            <string>ca://${DEVICE}:AMPL_W1CH0</string>
            </property>
           </widget>
          </item>
@@ -1632,29 +2070,8 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="4" colspan="2">
-          <widget class="QLabel" name="label_50">
-           <property name="font">
-            <font>
-             <pointsize>9</pointsize>
-             <weight>75</weight>
-             <bold>true</bold>
-             <underline>true</underline>
-            </font>
-           </property>
-           <property name="styleSheet">
-            <string notr="true">QLabel{background-color: #ffaaff;}</string>
-           </property>
-           <property name="text">
-            <string>Average Window 0 for Feedback</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignHCenter|Qt::AlignTop</set>
-           </property>
-          </widget>
-         </item>
-         <item row="14" column="1">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_10">
+         <item row="13" column="3">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_26">
            <property name="toolTip">
             <string/>
            </property>
@@ -1662,20 +2079,7 @@
             <set>Qt::AlignCenter</set>
            </property>
            <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:REFWGT9</string>
-           </property>
-          </widget>
-         </item>
-         <item row="13" column="4">
-          <widget class="PyDMLabel" name="PyDMLabel_9">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PHASE_W0CH8</string>
+            <string>ca://${DEVICE}:POC8</string>
            </property>
           </widget>
          </item>
@@ -1692,25 +2096,353 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="4">
-          <widget class="QLabel" name="label_14">
+         <item row="9" column="8">
+          <widget class="PyDMLabel" name="PyDMLabel_50">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PHASE_W2CH4</string>
+           </property>
+          </widget>
+         </item>
+         <item row="11" column="5">
+          <widget class="PyDMLabel" name="PyDMLabel_12">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AMPL_W0CH7</string>
+           </property>
+          </widget>
+         </item>
+         <item row="11" column="6">
+          <widget class="PyDMLabel" name="PyDMLabel_22">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PHASE_W1CH7</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="7">
+          <widget class="PyDMLabel" name="PyDMLabel_33">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AMPL_W1CH1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="8">
+          <widget class="PyDMLabel" name="PyDMLabel_45">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PHASE_W2CH5</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="0">
+          <widget class="QLabel" name="label_6">
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>RF_IN_5</string>
+           </property>
+          </widget>
+         </item>
+         <item row="13" column="2">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_16">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:FBWGT8</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="label_4">
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>RF_IN_3</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="5">
+          <widget class="PyDMLabel" name="PyDMLabel_13">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AMPL_W0CH1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="2">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_19">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:FBWGT5</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="5">
+          <widget class="PyDMLabel" name="PyDMLabel_15">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AMPL_W0CH5</string>
+           </property>
+          </widget>
+         </item>
+         <item row="11" column="4">
+          <widget class="PyDMLabel" name="PyDMLabel_8">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PHASE_W0CH7</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="9">
+          <widget class="PyDMLabel" name="PyDMLabel_55">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AMPL_W2CH5</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="2">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_11">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>1</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:FBWGT0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="8">
+          <widget class="PyDMLabel" name="PyDMLabel_41">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
              <horstretch>1</horstretch>
              <verstretch>1</verstretch>
             </sizepolicy>
            </property>
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>Phase</string>
+           <property name="toolTip">
+            <string/>
            </property>
            <property name="alignment">
             <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PHASE_W2CH0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="0">
+          <widget class="QLabel" name="label_3">
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>RF_IN_4</string>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="4">
+          <widget class="PyDMLabel" name="PyDMLabel_5">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PHASE_W0CH4</string>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="0">
+          <widget class="QLabel" name="label_5">
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>RF_IN_6</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="6">
+          <widget class="PyDMLabel" name="PyDMLabel_24">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PHASE_W1CH3</string>
+           </property>
+          </widget>
+         </item>
+         <item row="12" column="9">
+          <widget class="PyDMLabel" name="PyDMLabel_59">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AMPL_W2CH6</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="9">
+          <widget class="PyDMLabel" name="PyDMLabel_56">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AMPL_W2CH2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="1">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_6">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:REFWGT5</string>
+           </property>
+          </widget>
+         </item>
+         <item row="12" column="2">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_15">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:FBWGT6</string>
+           </property>
+          </widget>
+         </item>
+         <item row="13" column="9">
+          <widget class="PyDMLabel" name="PyDMLabel_57">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AMPL_W2CH8</string>
+           </property>
+          </widget>
+         </item>
+         <item row="12" column="4">
+          <widget class="PyDMLabel" name="PyDMLabel_7">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PHASE_W0CH6</string>
+           </property>
+          </widget>
+         </item>
+         <item row="13" column="1">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_9">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:REFWGT8</string>
            </property>
           </widget>
          </item>
@@ -1757,8 +2489,8 @@
            </property>
           </widget>
          </item>
-         <item row="14" column="3">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_28">
+         <item row="12" column="3">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_25">
            <property name="toolTip">
             <string/>
            </property>
@@ -1766,25 +2498,12 @@
             <set>Qt::AlignCenter</set>
            </property>
            <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:POC9</string>
+            <string>ca://${DEVICE}:POC6</string>
            </property>
           </widget>
          </item>
-         <item row="14" column="0">
-          <widget class="QLabel" name="label_10">
-           <property name="font">
-            <font>
-             <weight>50</weight>
-             <bold>false</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>RF_OUT_MON</string>
-           </property>
-          </widget>
-         </item>
-         <item row="13" column="9">
-          <widget class="PyDMLabel" name="PyDMLabel_57">
+         <item row="7" column="1">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_3">
            <property name="toolTip">
             <string/>
            </property>
@@ -1792,7 +2511,78 @@
             <set>Qt::AlignCenter</set>
            </property>
            <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AMPL_W2CH8</string>
+            <string>ca://${DEVICE}:REFWGT2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="3">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_22">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:POC4</string>
+           </property>
+          </widget>
+         </item>
+         <item row="14" column="2">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_18">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:FBWGT9</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="3">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_21">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>1</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:POC0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_2">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:REFWGT1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="9">
+          <widget class="PyDMLabel" name="PyDMLabel_54">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AMPL_W2CH3</string>
            </property>
           </widget>
          </item>
@@ -1818,8 +2608,8 @@
            </property>
           </widget>
          </item>
-         <item row="13" column="8">
-          <widget class="PyDMLabel" name="PyDMLabel_47">
+         <item row="9" column="1">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_5">
            <property name="toolTip">
             <string/>
            </property>
@@ -1827,116 +2617,7 @@
             <set>Qt::AlignCenter</set>
            </property>
            <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PHASE_W2CH8</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="3">
-          <widget class="QLabel" name="label_13">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>1</horstretch>
-             <verstretch>1</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>POC</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="13" column="1">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_9">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:REFWGT8</string>
-           </property>
-          </widget>
-         </item>
-         <item row="13" column="3">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_26">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:POC8</string>
-           </property>
-          </widget>
-         </item>
-         <item row="14" column="6">
-          <widget class="PyDMLabel" name="PyDMLabel_28">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PHASE_W1CH9</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="2">
-          <widget class="QLabel" name="label_12">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>1</horstretch>
-             <verstretch>1</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>Feedback Weight</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="14" column="4">
-          <widget class="PyDMLabel" name="PyDMLabel_10">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PHASE_W0CH9</string>
-           </property>
-          </widget>
-         </item>
-         <item row="14" column="2">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_18">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:FBWGT9</string>
+            <string>ca://${DEVICE}:REFWGT4</string>
            </property>
           </widget>
          </item>
@@ -1950,6 +2631,118 @@
            </property>
            <property name="channel" stdset="0">
             <string>ca://${DEVICE}:AMPL_W1CH9</string>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="5">
+          <widget class="PyDMLabel" name="PyDMLabel_20">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AMPL_W0CH4</string>
+           </property>
+          </widget>
+         </item>
+         <item row="12" column="0">
+          <widget class="QLabel" name="label_7">
+           <property name="font">
+            <font>
+             <weight>50</weight>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>RF_IN_2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="14" column="5">
+          <widget class="PyDMLabel" name="PyDMLabel_18">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AMPL_W0CH9</string>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="9">
+          <widget class="PyDMLabel" name="PyDMLabel_60">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AMPL_W2CH4</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="8">
+          <widget class="PyDMLabel" name="PyDMLabel_44">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PHASE_W2CH3</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="8" colspan="2">
+          <widget class="QLabel" name="label_52">
+           <property name="font">
+            <font>
+             <pointsize>9</pointsize>
+             <weight>75</weight>
+             <bold>true</bold>
+             <underline>true</underline>
+            </font>
+           </property>
+           <property name="styleSheet">
+            <string notr="true">QLabel{background-color: #ffff7f;}</string>
+           </property>
+           <property name="text">
+            <string>Average Window 2 for Diagnostics</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignHCenter|Qt::AlignTop</set>
+           </property>
+          </widget>
+         </item>
+         <item row="12" column="7">
+          <widget class="PyDMLabel" name="PyDMLabel_39">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AMPL_W1CH6</string>
+           </property>
+          </widget>
+         </item>
+         <item row="14" column="9">
+          <widget class="PyDMLabel" name="PyDMLabel_58">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:AMPL_W2CH9</string>
            </property>
           </widget>
          </item>
@@ -1975,6 +2768,136 @@
            </property>
           </widget>
          </item>
+         <item row="2" column="3">
+          <widget class="QLabel" name="label_13">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>1</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>POC</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="2">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_20">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:FBWGT3</string>
+           </property>
+          </widget>
+         </item>
+         <item row="12" column="6">
+          <widget class="PyDMLabel" name="PyDMLabel_29">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PHASE_W1CH6</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="6">
+          <widget class="PyDMLabel" name="PyDMLabel_26">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PHASE_W1CH2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="6">
+          <widget class="PyDMLabel" name="PyDMLabel_25">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:PHASE_W1CH5</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="3">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_30">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:POC3</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="7">
+          <widget class="QLabel" name="label_18">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>1</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Amplitude</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="4" colspan="2">
+          <widget class="QLabel" name="label_50">
+           <property name="font">
+            <font>
+             <pointsize>9</pointsize>
+             <weight>75</weight>
+             <bold>true</bold>
+             <underline>true</underline>
+            </font>
+           </property>
+           <property name="styleSheet">
+            <string notr="true">QLabel{background-color: #ffaaff;}</string>
+           </property>
+           <property name="text">
+            <string>Average Window 0 for Feedback</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignHCenter|Qt::AlignTop</set>
+           </property>
+          </widget>
+         </item>
          <item row="10" column="0">
           <widget class="QLabel" name="label_61">
            <property name="font">
@@ -1988,16 +2911,16 @@
            </property>
           </widget>
          </item>
-         <item row="4" column="1">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_2">
-           <property name="toolTip">
-            <string/>
+         <item row="3" column="0">
+          <widget class="QLabel" name="label_60">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
            </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:REFWGT1</string>
+           <property name="text">
+            <string>Down Converter</string>
            </property>
           </widget>
          </item>
@@ -2011,249 +2934,6 @@
            </property>
            <property name="channel" stdset="0">
             <string>ca://${DEVICE}:FBWGT1</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="3">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_23">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:POC1</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="4">
-          <widget class="PyDMLabel" name="PyDMLabel_2">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PHASE_W0CH1</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="5">
-          <widget class="PyDMLabel" name="PyDMLabel_13">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AMPL_W0CH1</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="6">
-          <widget class="PyDMLabel" name="PyDMLabel_23">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PHASE_W1CH1</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="7">
-          <widget class="PyDMLabel" name="PyDMLabel_33">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AMPL_W1CH1</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="8">
-          <widget class="PyDMLabel" name="PyDMLabel_43">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PHASE_W2CH1</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="9">
-          <widget class="PyDMLabel" name="PyDMLabel_53">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AMPL_W2CH1</string>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="1">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>1</horstretch>
-             <verstretch>1</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:REFWGT0</string>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="2">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_11">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>1</horstretch>
-             <verstretch>1</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:FBWGT0</string>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="3">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_21">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>1</horstretch>
-             <verstretch>1</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:POC0</string>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="4">
-          <widget class="PyDMLabel" name="PyDMLabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>1</horstretch>
-             <verstretch>1</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PHASE_W0CH0</string>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="5">
-          <widget class="PyDMLabel" name="PyDMLabel_11">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>1</horstretch>
-             <verstretch>1</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AMPL_W0CH0</string>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="6">
-          <widget class="PyDMLabel" name="PyDMLabel_21">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>1</horstretch>
-             <verstretch>1</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PHASE_W1CH0</string>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="7">
-          <widget class="PyDMLabel" name="PyDMLabel_31">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>1</horstretch>
-             <verstretch>1</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AMPL_W1CH0</string>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="8">
-          <widget class="PyDMLabel" name="PyDMLabel_41">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>1</horstretch>
-             <verstretch>1</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PHASE_W2CH0</string>
            </property>
           </widget>
          </item>
@@ -2276,552 +2956,6 @@
            </property>
           </widget>
          </item>
-         <item row="4" column="0">
-          <widget class="QLabel" name="label_2">
-           <property name="font">
-            <font>
-             <weight>50</weight>
-             <bold>false</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>RF_IN_1</string>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="0">
-          <widget class="QLabel" name="label">
-           <property name="font">
-            <font>
-             <weight>50</weight>
-             <bold>false</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>RF_IN_2</string>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="1">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_4">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:REFWGT3</string>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="2">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_20">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:FBWGT3</string>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="3">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_30">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:POC3</string>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="4">
-          <widget class="PyDMLabel" name="PyDMLabel_4">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PHASE_W0CH3</string>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="5">
-          <widget class="PyDMLabel" name="PyDMLabel_14">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AMPL_W0CH3</string>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="6">
-          <widget class="PyDMLabel" name="PyDMLabel_24">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PHASE_W1CH3</string>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="7">
-          <widget class="PyDMLabel" name="PyDMLabel_34">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AMPL_W1CH3</string>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="8">
-          <widget class="PyDMLabel" name="PyDMLabel_44">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PHASE_W2CH3</string>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="9">
-          <widget class="PyDMLabel" name="PyDMLabel_54">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AMPL_W2CH3</string>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="1">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_3">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:REFWGT2</string>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="2">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_14">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:FBWGT2</string>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="3">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_24">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:POC2</string>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="4">
-          <widget class="PyDMLabel" name="PyDMLabel_3">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PHASE_W0CH2</string>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="5">
-          <widget class="PyDMLabel" name="PyDMLabel_16">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AMPL_W0CH2</string>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="6">
-          <widget class="PyDMLabel" name="PyDMLabel_26">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PHASE_W1CH2</string>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="7">
-          <widget class="PyDMLabel" name="PyDMLabel_36">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AMPL_W1CH2</string>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="8">
-          <widget class="PyDMLabel" name="PyDMLabel_46">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PHASE_W2CH2</string>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="9">
-          <widget class="PyDMLabel" name="PyDMLabel_56">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AMPL_W2CH2</string>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="0">
-          <widget class="QLabel" name="label_4">
-           <property name="font">
-            <font>
-             <weight>50</weight>
-             <bold>false</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>RF_IN_3</string>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="0">
-          <widget class="QLabel" name="label_3">
-           <property name="font">
-            <font>
-             <weight>50</weight>
-             <bold>false</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>RF_IN_4</string>
-           </property>
-          </widget>
-         </item>
-         <item row="8" column="1">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_6">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:REFWGT5</string>
-           </property>
-          </widget>
-         </item>
-         <item row="8" column="2">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_19">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:FBWGT5</string>
-           </property>
-          </widget>
-         </item>
-         <item row="8" column="3">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_29">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:POC5</string>
-           </property>
-          </widget>
-         </item>
-         <item row="8" column="4">
-          <widget class="PyDMLabel" name="PyDMLabel_6">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PHASE_W0CH5</string>
-           </property>
-          </widget>
-         </item>
-         <item row="8" column="5">
-          <widget class="PyDMLabel" name="PyDMLabel_15">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AMPL_W0CH5</string>
-           </property>
-          </widget>
-         </item>
-         <item row="8" column="6">
-          <widget class="PyDMLabel" name="PyDMLabel_25">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PHASE_W1CH5</string>
-           </property>
-          </widget>
-         </item>
-         <item row="8" column="7">
-          <widget class="PyDMLabel" name="PyDMLabel_35">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AMPL_W1CH5</string>
-           </property>
-          </widget>
-         </item>
-         <item row="8" column="8">
-          <widget class="PyDMLabel" name="PyDMLabel_45">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PHASE_W2CH5</string>
-           </property>
-          </widget>
-         </item>
-         <item row="8" column="9">
-          <widget class="PyDMLabel" name="PyDMLabel_55">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AMPL_W2CH5</string>
-           </property>
-          </widget>
-         </item>
-         <item row="9" column="1">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_5">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:REFWGT4</string>
-           </property>
-          </widget>
-         </item>
-         <item row="9" column="2">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_12">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:FBWGT4</string>
-           </property>
-          </widget>
-         </item>
-         <item row="9" column="3">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_22">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:POC4</string>
-           </property>
-          </widget>
-         </item>
-         <item row="9" column="4">
-          <widget class="PyDMLabel" name="PyDMLabel_5">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PHASE_W0CH4</string>
-           </property>
-          </widget>
-         </item>
-         <item row="9" column="5">
-          <widget class="PyDMLabel" name="PyDMLabel_20">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AMPL_W0CH4</string>
-           </property>
-          </widget>
-         </item>
-         <item row="9" column="6">
-          <widget class="PyDMLabel" name="PyDMLabel_30">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PHASE_W1CH4</string>
-           </property>
-          </widget>
-         </item>
-         <item row="9" column="7">
-          <widget class="PyDMLabel" name="PyDMLabel_40">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AMPL_W1CH4</string>
-           </property>
-          </widget>
-         </item>
-         <item row="9" column="8">
-          <widget class="PyDMLabel" name="PyDMLabel_50">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PHASE_W2CH4</string>
-           </property>
-          </widget>
-         </item>
-         <item row="9" column="9">
-          <widget class="PyDMLabel" name="PyDMLabel_60">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AMPL_W2CH4</string>
-           </property>
-          </widget>
-         </item>
-         <item row="8" column="0">
-          <widget class="QLabel" name="label_6">
-           <property name="font">
-            <font>
-             <weight>50</weight>
-             <bold>false</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>RF_IN_5</string>
-           </property>
-          </widget>
-         </item>
-         <item row="9" column="0">
-          <widget class="QLabel" name="label_5">
-           <property name="font">
-            <font>
-             <weight>50</weight>
-             <bold>false</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>RF_IN_6</string>
-           </property>
-          </widget>
-         </item>
          <item row="11" column="1">
           <widget class="PyDMLineEdit" name="PyDMLineEdit_8">
            <property name="toolTip">
@@ -2835,21 +2969,30 @@
            </property>
           </widget>
          </item>
-         <item row="11" column="2">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_17">
-           <property name="toolTip">
-            <string/>
+         <item row="2" column="6">
+          <widget class="QLabel" name="label_16">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>1</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Phase</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:FBWGT7</string>
            </property>
           </widget>
          </item>
-         <item row="11" column="3">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_27">
+         <item row="4" column="6">
+          <widget class="PyDMLabel" name="PyDMLabel_23">
            <property name="toolTip">
             <string/>
            </property>
@@ -2857,12 +3000,12 @@
             <set>Qt::AlignCenter</set>
            </property>
            <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:POC7</string>
+            <string>ca://${DEVICE}:PHASE_W1CH1</string>
            </property>
           </widget>
          </item>
-         <item row="11" column="4">
-          <widget class="PyDMLabel" name="PyDMLabel_8">
+         <item row="13" column="7">
+          <widget class="PyDMLabel" name="PyDMLabel_37">
            <property name="toolTip">
             <string/>
            </property>
@@ -2870,163 +3013,7 @@
             <set>Qt::AlignCenter</set>
            </property>
            <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PHASE_W0CH7</string>
-           </property>
-          </widget>
-         </item>
-         <item row="11" column="5">
-          <widget class="PyDMLabel" name="PyDMLabel_12">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AMPL_W0CH7</string>
-           </property>
-          </widget>
-         </item>
-         <item row="11" column="6">
-          <widget class="PyDMLabel" name="PyDMLabel_22">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PHASE_W1CH7</string>
-           </property>
-          </widget>
-         </item>
-         <item row="11" column="7">
-          <widget class="PyDMLabel" name="PyDMLabel_32">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AMPL_W1CH7</string>
-           </property>
-          </widget>
-         </item>
-         <item row="11" column="8">
-          <widget class="PyDMLabel" name="PyDMLabel_42">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PHASE_W2CH7</string>
-           </property>
-          </widget>
-         </item>
-         <item row="11" column="9">
-          <widget class="PyDMLabel" name="PyDMLabel_52">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AMPL_W2CH7</string>
-           </property>
-          </widget>
-         </item>
-         <item row="12" column="1">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_7">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:REFWGT6</string>
-           </property>
-          </widget>
-         </item>
-         <item row="12" column="2">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_15">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:FBWGT6</string>
-           </property>
-          </widget>
-         </item>
-         <item row="12" column="3">
-          <widget class="PyDMLineEdit" name="PyDMLineEdit_25">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:POC6</string>
-           </property>
-          </widget>
-         </item>
-         <item row="12" column="4">
-          <widget class="PyDMLabel" name="PyDMLabel_7">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PHASE_W0CH6</string>
-           </property>
-          </widget>
-         </item>
-         <item row="12" column="5">
-          <widget class="PyDMLabel" name="PyDMLabel_19">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AMPL_W0CH6</string>
-           </property>
-          </widget>
-         </item>
-         <item row="12" column="6">
-          <widget class="PyDMLabel" name="PyDMLabel_29">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:PHASE_W1CH6</string>
-           </property>
-          </widget>
-         </item>
-         <item row="12" column="7">
-          <widget class="PyDMLabel" name="PyDMLabel_39">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AMPL_W1CH6</string>
+            <string>ca://${DEVICE}:AMPL_W1CH8</string>
            </property>
           </widget>
          </item>
@@ -3043,8 +3030,8 @@
            </property>
           </widget>
          </item>
-         <item row="12" column="9">
-          <widget class="PyDMLabel" name="PyDMLabel_59">
+         <item row="14" column="6">
+          <widget class="PyDMLabel" name="PyDMLabel_28">
            <property name="toolTip">
             <string/>
            </property>
@@ -3052,33 +3039,115 @@
             <set>Qt::AlignCenter</set>
            </property>
            <property name="channel" stdset="0">
-            <string>ca://${DEVICE}:AMPL_W2CH6</string>
+            <string>ca://${DEVICE}:PHASE_W1CH9</string>
            </property>
           </widget>
          </item>
-         <item row="11" column="0">
-          <widget class="QLabel" name="label_8">
-           <property name="font">
-            <font>
-             <weight>50</weight>
-             <bold>false</bold>
-            </font>
+         <item row="14" column="1">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_10">
+           <property name="toolTip">
+            <string/>
            </property>
-           <property name="text">
-            <string>RF_IN_1</string>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:REFWGT9</string>
            </property>
           </widget>
          </item>
-         <item row="12" column="0">
-          <widget class="QLabel" name="label_7">
-           <property name="font">
-            <font>
-             <weight>50</weight>
-             <bold>false</bold>
-            </font>
+         <item row="11" column="3">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_27">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:POC7</string>
+           </property>
+          </widget>
+         </item>
+         <item row="11" column="2">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_17">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${DEVICE}:FBWGT7</string>
+           </property>
+          </widget>
+         </item>
+         <item row="15" column="4" colspan="2">
+          <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton_6">
+           <property name="toolTip">
+            <string/>
            </property>
            <property name="text">
-            <string>RF_IN_2</string>
+            <string>See/Change Window</string>
+           </property>
+           <property name="filenames" stdset="0">
+            <stringlist>
+             <string>hls_complex_window.ui</string>
+            </stringlist>
+           </property>
+           <property name="macros" stdset="0">
+            <stringlist>
+             <string>{&quot;TITLE&quot;:&quot;Feedback Complex Window&quot;, &quot;R&quot;:&quot;CPXWND&quot;, &quot;N&quot;:&quot;0&quot;}</string>
+            </stringlist>
+           </property>
+           <property name="openInNewWindow" stdset="0">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="15" column="6" colspan="2">
+          <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton_7">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="text">
+            <string>See/Change Window</string>
+           </property>
+           <property name="filenames" stdset="0">
+            <stringlist>
+             <string>hls_complex_window.ui</string>
+            </stringlist>
+           </property>
+           <property name="macros" stdset="0">
+            <stringlist>
+             <string>{&quot;TITLE&quot;:&quot;Diagnostics Complex Window 1&quot;, &quot;R&quot;:&quot;CPXWND&quot;, &quot;N&quot;:&quot;1&quot;}</string>
+            </stringlist>
+           </property>
+           <property name="openInNewWindow" stdset="0">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="15" column="8" colspan="2">
+          <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton_8">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="text">
+            <string>See/Change Window</string>
+           </property>
+           <property name="filenames" stdset="0">
+            <stringlist>
+             <string>hls_complex_window.ui</string>
+            </stringlist>
+           </property>
+           <property name="macros" stdset="0">
+            <stringlist>
+             <string>{&quot;TITLE&quot;:&quot;Diagnostic Complex Window 2&quot;, &quot;R&quot;:&quot;CPXWND&quot;, &quot;N&quot;:&quot;2&quot;}</string>
+            </stringlist>
+           </property>
+           <property name="openInNewWindow" stdset="0">
+            <bool>true</bool>
            </property>
           </widget>
          </item>
@@ -4232,12 +4301,12 @@ Conversion Factor(kV/Count)</string>
           </widget>
          </item>
          <item row="7" column="1">
-          <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton_6">
+          <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton_9">
            <property name="toolTip">
             <string/>
            </property>
            <property name="text">
-            <string>Feddback Complex Window</string>
+            <string>See/Change Baseband I/Q Driver Waveforms</string>
            </property>
            <property name="filenames" stdset="0">
             <stringlist>
@@ -4246,7 +4315,7 @@ Conversion Factor(kV/Count)</string>
            </property>
            <property name="macros" stdset="0">
             <stringlist>
-             <string>{&quot;TITLE&quot;:&quot;Feedback Complex Window&quot;, &quot;R&quot;:&quot;CPXWND&quot;, &quot;N&quot;:&quot;0&quot;}</string>
+             <string>{&quot;TITLE&quot;:&quot;Baseband I/Q Driver Waveforms&quot;, &quot;R&quot;:&quot;BL&quot;, &quot;N&quot;:&quot;&quot;}</string>
             </stringlist>
            </property>
            <property name="openInNewWindow" stdset="0">

--- a/llrf_hls.ui
+++ b/llrf_hls.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1934</width>
-    <height>1283</height>
+    <width>1012</width>
+    <height>1261</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -36,32 +36,862 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>1922</width>
-        <height>1349</height>
+        <width>1000</width>
+        <height>1301</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout_8">
-       <item row="1" column="0">
-        <widget class="Line" name="line">
-         <property name="lineWidth">
-          <number>4</number>
+       <item row="2" column="0">
+        <widget class="QFrame" name="frame">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>300</height>
+          </size>
          </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>300</height>
+          </size>
+         </property>
+         <property name="frameShape">
+          <enum>QFrame::StyledPanel</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Raised</enum>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_4">
+          <item>
+           <layout class="QGridLayout" name="gridLayout_7">
+            <item row="6" column="0">
+             <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton">
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>IQ Measurement Waveforms</string>
+              </property>
+              <property name="filenames" stdset="0">
+               <stringlist>
+                <string>iqwaveform.ui</string>
+                <string>iqwaveform.ui</string>
+                <string>iqwaveform.ui</string>
+                <string>iqwaveform.ui</string>
+                <string>iqwaveform.ui</string>
+                <string>iqwaveform.ui</string>
+                <string>iqwaveform.ui</string>
+                <string>iqwaveform.ui</string>
+                <string>iqwaveform.ui</string>
+                <string>iqwaveform.ui</string>
+               </stringlist>
+              </property>
+              <property name="titles" stdset="0">
+               <stringlist>
+                <string>IQ-Waveform - DwnCon:RF_IN_1</string>
+                <string>IQ-Waveform - DwnCon:RF_IN_2</string>
+                <string>IQ-Waveform - DwnCon:RF_IN_3</string>
+                <string>IQ-Waveform - DwnCon:RF_IN_4</string>
+                <string>IQ-Waveform - DwnCon:RF_IN_5</string>
+                <string>IQ-Waveform - DwnCon:RF_IN_6</string>
+                <string>IQ-Waveform - UpCon:RF_IN_1</string>
+                <string>IQ-Waveform - UpCon:RF_IN_2</string>
+                <string>IQ-Waveform - UpCon:RF_IN_3</string>
+                <string>IQ-Waveform - UpCon:RF_OUT_MON</string>
+               </stringlist>
+              </property>
+              <property name="macros" stdset="0">
+               <stringlist>
+                <string>{&quot;N&quot;:&quot;1&quot;}</string>
+                <string>{&quot;N&quot;:&quot;0&quot;}</string>
+                <string>{&quot;N&quot;:&quot;3&quot;}</string>
+                <string>{&quot;N&quot;:&quot;2&quot;}</string>
+                <string>{&quot;N&quot;:&quot;5&quot;}</string>
+                <string>{&quot;N&quot;:&quot;4&quot;}</string>
+                <string>{&quot;N&quot;:&quot;7&quot;}</string>
+                <string>{&quot;N&quot;:&quot;6&quot;}</string>
+                <string>{&quot;N&quot;:&quot;8&quot;}</string>
+                <string>{&quot;N&quot;:&quot;9&quot;}</string>
+               </stringlist>
+              </property>
+              <property name="openInNewWindow" stdset="0">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="4">
+             <spacer name="horizontalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="5" column="0">
+             <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton_9">
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="text">
+               <string>See/Change Baseband I/Q Driver Waveforms</string>
+              </property>
+              <property name="filenames" stdset="0">
+               <stringlist>
+                <string>hls_complex_window.ui</string>
+               </stringlist>
+              </property>
+              <property name="macros" stdset="0">
+               <stringlist>
+                <string>{&quot;TITLE&quot;:&quot;Baseband I/Q Driver Waveforms&quot;, &quot;R&quot;:&quot;BL&quot;, &quot;N&quot;:&quot;&quot;}</string>
+               </stringlist>
+              </property>
+              <property name="openInNewWindow" stdset="0">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0" rowspan="5" colspan="2">
+             <layout class="QGridLayout" name="gridLayout_3">
+              <item row="1" column="0">
+               <widget class="QLabel" name="label_35">
+                <property name="font">
+                 <font>
+                  <pointsize>10</pointsize>
+                  <weight>75</weight>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Trigger Mode</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="PyDMEnumButton" name="PyDMEnumButton_3">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>16777215</width>
+                  <height>40</height>
+                 </size>
+                </property>
+                <property name="toolTip">
+                 <string/>
+                </property>
+                <property name="styleSheet">
+                 <string notr="true">QPushButton{font: 8px;}</string>
+                </property>
+                <property name="channel" stdset="0">
+                 <string>ca://${DEVICE}:REFSUBENB</string>
+                </property>
+                <property name="orientation" stdset="0">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="marginTop" stdset="0">
+                 <number>0</number>
+                </property>
+                <property name="marginBottom" stdset="0">
+                 <number>0</number>
+                </property>
+                <property name="marginLeft" stdset="0">
+                 <number>0</number>
+                </property>
+                <property name="marginRight" stdset="0">
+                 <number>0</number>
+                </property>
+                <property name="horizontalSpacing" stdset="0">
+                 <number>0</number>
+                </property>
+                <property name="verticalSpacing" stdset="0">
+                 <number>0</number>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="label_36">
+                <property name="font">
+                 <font>
+                  <pointsize>10</pointsize>
+                  <weight>75</weight>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Reference Subtraction</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="PyDMEnumButton" name="PyDMEnumButton_2">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>16777215</width>
+                  <height>40</height>
+                 </size>
+                </property>
+                <property name="toolTip">
+                 <string/>
+                </property>
+                <property name="styleSheet">
+                 <string notr="true">QPushButton{font: 8px;}</string>
+                </property>
+                <property name="channel" stdset="0">
+                 <string>ca://${DEVICE}:MODECFG</string>
+                </property>
+                <property name="orientation" stdset="0">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="marginTop" stdset="0">
+                 <number>0</number>
+                </property>
+                <property name="marginBottom" stdset="0">
+                 <number>0</number>
+                </property>
+                <property name="marginLeft" stdset="0">
+                 <number>0</number>
+                </property>
+                <property name="marginRight" stdset="0">
+                 <number>0</number>
+                </property>
+                <property name="horizontalSpacing" stdset="0">
+                 <number>0</number>
+                </property>
+                <property name="verticalSpacing" stdset="0">
+                 <number>0</number>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="0">
+               <widget class="QLabel" name="label_38">
+                <property name="font">
+                 <font>
+                  <pointsize>10</pointsize>
+                  <weight>75</weight>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Amplitude Feedback</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="1">
+               <widget class="PyDMEnumButton" name="PyDMEnumButton_5">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>16777215</width>
+                  <height>40</height>
+                 </size>
+                </property>
+                <property name="toolTip">
+                 <string/>
+                </property>
+                <property name="styleSheet">
+                 <string notr="true">QPushButton{font: 8px;}</string>
+                </property>
+                <property name="channel" stdset="0">
+                 <string>ca://${DEVICE}:AFBENB</string>
+                </property>
+                <property name="orientation" stdset="0">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="marginTop" stdset="0">
+                 <number>0</number>
+                </property>
+                <property name="marginBottom" stdset="0">
+                 <number>0</number>
+                </property>
+                <property name="marginLeft" stdset="0">
+                 <number>0</number>
+                </property>
+                <property name="marginRight" stdset="0">
+                 <number>0</number>
+                </property>
+                <property name="horizontalSpacing" stdset="0">
+                 <number>0</number>
+                </property>
+                <property name="verticalSpacing" stdset="0">
+                 <number>0</number>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="PyDMEnumButton" name="PyDMEnumButton">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>16777215</width>
+                  <height>40</height>
+                 </size>
+                </property>
+                <property name="toolTip">
+                 <string/>
+                </property>
+                <property name="styleSheet">
+                 <string notr="true">QPushButton{font: 8px;}</string>
+                </property>
+                <property name="channel" stdset="0">
+                 <string>ca://${DEVICE}:STRMENB</string>
+                </property>
+                <property name="orientation" stdset="0">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="marginTop" stdset="0">
+                 <number>0</number>
+                </property>
+                <property name="marginBottom" stdset="0">
+                 <number>0</number>
+                </property>
+                <property name="marginLeft" stdset="0">
+                 <number>0</number>
+                </property>
+                <property name="marginRight" stdset="0">
+                 <number>0</number>
+                </property>
+                <property name="horizontalSpacing" stdset="0">
+                 <number>0</number>
+                </property>
+                <property name="verticalSpacing" stdset="0">
+                 <number>0</number>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0">
+               <widget class="QLabel" name="label_37">
+                <property name="font">
+                 <font>
+                  <pointsize>10</pointsize>
+                  <weight>75</weight>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Phase Feedback</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="1">
+               <spacer name="verticalSpacer_4">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>40</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="label_34">
+                <property name="font">
+                 <font>
+                  <pointsize>10</pointsize>
+                  <weight>75</weight>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Stream </string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="1">
+               <widget class="PyDMEnumButton" name="PyDMEnumButton_4">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>16777215</width>
+                  <height>40</height>
+                 </size>
+                </property>
+                <property name="toolTip">
+                 <string/>
+                </property>
+                <property name="styleSheet">
+                 <string notr="true">QPushButton{font: 8px;}</string>
+                </property>
+                <property name="channel" stdset="0">
+                 <string>ca://${DEVICE}:PFBENB</string>
+                </property>
+                <property name="orientation" stdset="0">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="marginTop" stdset="0">
+                 <number>0</number>
+                </property>
+                <property name="marginBottom" stdset="0">
+                 <number>0</number>
+                </property>
+                <property name="marginLeft" stdset="0">
+                 <number>0</number>
+                </property>
+                <property name="marginRight" stdset="0">
+                 <number>0</number>
+                </property>
+                <property name="horizontalSpacing" stdset="0">
+                 <number>0</number>
+                </property>
+                <property name="verticalSpacing" stdset="0">
+                 <number>0</number>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item row="0" column="3">
+             <layout class="QGridLayout" name="gridLayout_5">
+              <item row="0" column="0">
+               <widget class="QLabel" name="label_43">
+                <property name="font">
+                 <font>
+                  <weight>75</weight>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Loop Count</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="PyDMLabel" name="PyDMLabel_97">
+                <property name="toolTip">
+                 <string/>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+                <property name="channel" stdset="0">
+                 <string>ca://${DEVICE}:LOOPCNT</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="label_44">
+                <property name="font">
+                 <font>
+                  <weight>75</weight>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Drop Count</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="PyDMLabel" name="PyDMLabel_98">
+                <property name="toolTip">
+                 <string/>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+                <property name="channel" stdset="0">
+                 <string>ca://${DEVICE}:DROPCNT</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item row="3" column="3" rowspan="2" colspan="3">
+             <layout class="QGridLayout" name="gridLayout_4">
+              <item row="2" column="0">
+               <widget class="QLabel" name="label_48">
+                <property name="font">
+                 <font>
+                  <weight>75</weight>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Upper Limit</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="1">
+               <widget class="PyDMLineEdit" name="PyDMLineEdit_48">
+                <property name="toolTip">
+                 <string/>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+                <property name="channel" stdset="0">
+                 <string>ca://${DEVICE}:PCORLOL</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="2">
+               <widget class="PyDMLineEdit" name="PyDMLineEdit_49">
+                <property name="toolTip">
+                 <string/>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+                <property name="channel" stdset="0">
+                 <string>ca://${DEVICE}:ACORUPL</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="2">
+               <widget class="PyDMLineEdit" name="PyDMLineEdit_50">
+                <property name="toolTip">
+                 <string/>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+                <property name="channel" stdset="0">
+                 <string>ca://${DEVICE}:ACORLOL</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="2">
+               <widget class="QLabel" name="label_46">
+                <property name="font">
+                 <font>
+                  <weight>75</weight>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Amplitude Correction</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="3">
+               <widget class="PyDMLineEdit" name="PyDMLineEdit_51">
+                <property name="toolTip">
+                 <string/>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+                <property name="channel" stdset="0">
+                 <string>ca://${DEVICE}:ADRVUPL</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QLabel" name="label_45">
+                <property name="font">
+                 <font>
+                  <weight>75</weight>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Phase Correction</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0">
+               <widget class="QLabel" name="label_49">
+                <property name="font">
+                 <font>
+                  <weight>75</weight>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Lower Limit</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="PyDMLineEdit" name="PyDMLineEdit_47">
+                <property name="toolTip">
+                 <string/>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+                <property name="channel" stdset="0">
+                 <string>ca://${DEVICE}:PCORUPL</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="3">
+               <widget class="QLabel" name="label_47">
+                <property name="font">
+                 <font>
+                  <weight>75</weight>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Amplitude Drive</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="3">
+               <widget class="PyDMLineEdit" name="PyDMLineEdit_52">
+                <property name="toolTip">
+                 <string/>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+                <property name="channel" stdset="0">
+                 <string>ca://${DEVICE}:ACORLOL</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="2">
+               <spacer name="verticalSpacer">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>40</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+            <item row="0" column="5" rowspan="3">
+             <layout class="QGridLayout" name="gridLayout_6">
+              <item row="2" column="3" colspan="2">
+               <widget class="PyDMLineEdit" name="PyDMLineEdit_45">
+                <property name="toolTip">
+                 <string/>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+                <property name="channel" stdset="0">
+                 <string>ca://${DEVICE}:PGAIN</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="2">
+               <widget class="QLabel" name="label_41">
+                <property name="font">
+                 <font>
+                  <pointsize>10</pointsize>
+                  <weight>75</weight>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Phase Loop Gain</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="3" colspan="2">
+               <widget class="PyDMLineEdit" name="PyDMLineEdit_44">
+                <property name="toolTip">
+                 <string/>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+                <property name="channel" stdset="0">
+                 <string>ca://${DEVICE}:FBPOC</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="3" colspan="2">
+               <widget class="PyDMLineEdit" name="PyDMLineEdit_43">
+                <property name="toolTip">
+                 <string/>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+                <property name="channel" stdset="0">
+                 <string>ca://${DEVICE}:REFPOC</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="2">
+               <widget class="QLabel" name="label_39">
+                <property name="font">
+                 <font>
+                  <pointsize>10</pointsize>
+                  <weight>75</weight>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Ref. POC</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="2">
+               <widget class="QLabel" name="label_42">
+                <property name="font">
+                 <font>
+                  <pointsize>10</pointsize>
+                  <weight>75</weight>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Amplitude Loop Gain</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="2">
+               <widget class="QLabel" name="label_40">
+                <property name="font">
+                 <font>
+                  <pointsize>10</pointsize>
+                  <weight>75</weight>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Feedback POC</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="3" colspan="2">
+               <widget class="PyDMLineEdit" name="PyDMLineEdit_46">
+                <property name="toolTip">
+                 <string/>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+                <property name="channel" stdset="0">
+                 <string>ca://${DEVICE}:AGAIN</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="2">
+               <widget class="QLabel" name="label_77">
+                <property name="font">
+                 <font>
+                  <pointsize>10</pointsize>
+                  <weight>75</weight>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Beam Peak Voltage
+Conversion Factor(kV/Count)</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="3" colspan="2">
+               <widget class="PyDMLineEdit" name="PyDMLineEdit_42">
+                <property name="toolTip">
+                 <string/>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+                <property name="channel" stdset="0">
+                 <string>ca://${DEVICE}:BVOLTCONV</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item row="0" column="2">
+             <spacer name="horizontalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+         </layout>
         </widget>
        </item>
-       <item row="3" column="0">
-        <widget class="Line" name="line_3">
-         <property name="lineWidth">
-          <number>4</number>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0">
+       <item row="6" column="0">
         <layout class="QGridLayout" name="gridLayout_2">
          <item row="2" column="10">
           <widget class="PyDMLabel" name="PyDMLabel_89">
@@ -1439,7 +2269,17 @@
          </item>
         </layout>
        </item>
-       <item row="2" column="0">
+       <item row="5" column="0">
+        <widget class="Line" name="line_3">
+         <property name="lineWidth">
+          <number>4</number>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
         <layout class="QGridLayout" name="gridLayout">
          <item row="14" column="0">
           <widget class="QLabel" name="label_10">
@@ -3082,7 +3922,7 @@
            </property>
           </widget>
          </item>
-         <item row="15" column="4" colspan="2">
+         <item row="1" column="4" colspan="2">
           <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton_6">
            <property name="toolTip">
             <string/>
@@ -3105,7 +3945,7 @@
            </property>
           </widget>
          </item>
-         <item row="15" column="6" colspan="2">
+         <item row="1" column="6" colspan="2">
           <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton_7">
            <property name="toolTip">
             <string/>
@@ -3128,7 +3968,7 @@
            </property>
           </widget>
          </item>
-         <item row="15" column="8" colspan="2">
+         <item row="1" column="8" colspan="2">
           <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton_8">
            <property name="toolTip">
             <string/>
@@ -3153,779 +3993,7 @@
          </item>
         </layout>
        </item>
-       <item row="0" column="0">
-        <widget class="QFrame" name="frame">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>300</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>400</height>
-          </size>
-         </property>
-         <property name="frameShape">
-          <enum>QFrame::StyledPanel</enum>
-         </property>
-         <property name="frameShadow">
-          <enum>QFrame::Raised</enum>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_4">
-          <item>
-           <layout class="QGridLayout" name="gridLayout_7">
-            <item row="0" column="0" rowspan="5" colspan="2">
-             <layout class="QGridLayout" name="gridLayout_3">
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_34">
-                <property name="font">
-                 <font>
-                  <pointsize>10</pointsize>
-                  <weight>75</weight>
-                  <bold>true</bold>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Stream </string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="label_36">
-                <property name="font">
-                 <font>
-                  <pointsize>10</pointsize>
-                  <weight>75</weight>
-                  <bold>true</bold>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Reference Subtraction</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="PyDMEnumButton" name="PyDMEnumButton">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="maximumSize">
-                 <size>
-                  <width>16777215</width>
-                  <height>40</height>
-                 </size>
-                </property>
-                <property name="toolTip">
-                 <string/>
-                </property>
-                <property name="styleSheet">
-                 <string notr="true">QPushButton{font: 8px;}</string>
-                </property>
-                <property name="channel" stdset="0">
-                 <string>ca://${DEVICE}:STRMENB</string>
-                </property>
-                <property name="orientation" stdset="0">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="marginTop" stdset="0">
-                 <number>0</number>
-                </property>
-                <property name="marginBottom" stdset="0">
-                 <number>0</number>
-                </property>
-                <property name="marginLeft" stdset="0">
-                 <number>0</number>
-                </property>
-                <property name="marginRight" stdset="0">
-                 <number>0</number>
-                </property>
-                <property name="horizontalSpacing" stdset="0">
-                 <number>0</number>
-                </property>
-                <property name="verticalSpacing" stdset="0">
-                 <number>0</number>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="label_35">
-                <property name="font">
-                 <font>
-                  <pointsize>10</pointsize>
-                  <weight>75</weight>
-                  <bold>true</bold>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Trigger Mode</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="1">
-               <widget class="PyDMEnumButton" name="PyDMEnumButton_5">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="maximumSize">
-                 <size>
-                  <width>16777215</width>
-                  <height>40</height>
-                 </size>
-                </property>
-                <property name="toolTip">
-                 <string/>
-                </property>
-                <property name="styleSheet">
-                 <string notr="true">QPushButton{font: 8px;}</string>
-                </property>
-                <property name="channel" stdset="0">
-                 <string>ca://${DEVICE}:AFBENB</string>
-                </property>
-                <property name="orientation" stdset="0">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="marginTop" stdset="0">
-                 <number>0</number>
-                </property>
-                <property name="marginBottom" stdset="0">
-                 <number>0</number>
-                </property>
-                <property name="marginLeft" stdset="0">
-                 <number>0</number>
-                </property>
-                <property name="marginRight" stdset="0">
-                 <number>0</number>
-                </property>
-                <property name="horizontalSpacing" stdset="0">
-                 <number>0</number>
-                </property>
-                <property name="verticalSpacing" stdset="0">
-                 <number>0</number>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="PyDMEnumButton" name="PyDMEnumButton_2">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="maximumSize">
-                 <size>
-                  <width>16777215</width>
-                  <height>40</height>
-                 </size>
-                </property>
-                <property name="toolTip">
-                 <string/>
-                </property>
-                <property name="styleSheet">
-                 <string notr="true">QPushButton{font: 8px;}</string>
-                </property>
-                <property name="channel" stdset="0">
-                 <string>ca://${DEVICE}:MODECFG</string>
-                </property>
-                <property name="orientation" stdset="0">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="marginTop" stdset="0">
-                 <number>0</number>
-                </property>
-                <property name="marginBottom" stdset="0">
-                 <number>0</number>
-                </property>
-                <property name="marginLeft" stdset="0">
-                 <number>0</number>
-                </property>
-                <property name="marginRight" stdset="0">
-                 <number>0</number>
-                </property>
-                <property name="horizontalSpacing" stdset="0">
-                 <number>0</number>
-                </property>
-                <property name="verticalSpacing" stdset="0">
-                 <number>0</number>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0">
-               <widget class="QLabel" name="label_37">
-                <property name="font">
-                 <font>
-                  <pointsize>10</pointsize>
-                  <weight>75</weight>
-                  <bold>true</bold>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Phase Feedback</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="0">
-               <widget class="QLabel" name="label_38">
-                <property name="font">
-                 <font>
-                  <pointsize>10</pointsize>
-                  <weight>75</weight>
-                  <bold>true</bold>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Amplitude Feedback</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="5" column="1">
-               <spacer name="verticalSpacer_4">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>20</width>
-                  <height>40</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item row="3" column="1">
-               <widget class="PyDMEnumButton" name="PyDMEnumButton_4">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="maximumSize">
-                 <size>
-                  <width>16777215</width>
-                  <height>40</height>
-                 </size>
-                </property>
-                <property name="toolTip">
-                 <string/>
-                </property>
-                <property name="styleSheet">
-                 <string notr="true">QPushButton{font: 8px;}</string>
-                </property>
-                <property name="channel" stdset="0">
-                 <string>ca://${DEVICE}:PFBENB</string>
-                </property>
-                <property name="orientation" stdset="0">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="marginTop" stdset="0">
-                 <number>0</number>
-                </property>
-                <property name="marginBottom" stdset="0">
-                 <number>0</number>
-                </property>
-                <property name="marginLeft" stdset="0">
-                 <number>0</number>
-                </property>
-                <property name="marginRight" stdset="0">
-                 <number>0</number>
-                </property>
-                <property name="horizontalSpacing" stdset="0">
-                 <number>0</number>
-                </property>
-                <property name="verticalSpacing" stdset="0">
-                 <number>0</number>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="PyDMEnumButton" name="PyDMEnumButton_3">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="maximumSize">
-                 <size>
-                  <width>16777215</width>
-                  <height>40</height>
-                 </size>
-                </property>
-                <property name="toolTip">
-                 <string/>
-                </property>
-                <property name="styleSheet">
-                 <string notr="true">QPushButton{font: 8px;}</string>
-                </property>
-                <property name="channel" stdset="0">
-                 <string>ca://${DEVICE}:REFSUBENB</string>
-                </property>
-                <property name="orientation" stdset="0">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="marginTop" stdset="0">
-                 <number>0</number>
-                </property>
-                <property name="marginBottom" stdset="0">
-                 <number>0</number>
-                </property>
-                <property name="marginLeft" stdset="0">
-                 <number>0</number>
-                </property>
-                <property name="marginRight" stdset="0">
-                 <number>0</number>
-                </property>
-                <property name="horizontalSpacing" stdset="0">
-                 <number>0</number>
-                </property>
-                <property name="verticalSpacing" stdset="0">
-                 <number>0</number>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item row="0" column="3">
-             <layout class="QGridLayout" name="gridLayout_5">
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_43">
-                <property name="font">
-                 <font>
-                  <weight>75</weight>
-                  <bold>true</bold>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Loop Count</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="PyDMLabel" name="PyDMLabel_97">
-                <property name="toolTip">
-                 <string/>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-                <property name="channel" stdset="0">
-                 <string>ca://${DEVICE}:LOOPCNT</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="label_44">
-                <property name="font">
-                 <font>
-                  <weight>75</weight>
-                  <bold>true</bold>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Drop Count</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="PyDMLabel" name="PyDMLabel_98">
-                <property name="toolTip">
-                 <string/>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-                <property name="channel" stdset="0">
-                 <string>ca://${DEVICE}:DROPCNT</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item row="0" column="4">
-             <spacer name="horizontalSpacer_3">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="3" column="3" rowspan="2" colspan="3">
-             <layout class="QGridLayout" name="gridLayout_4">
-              <item row="2" column="0">
-               <widget class="QLabel" name="label_48">
-                <property name="font">
-                 <font>
-                  <weight>75</weight>
-                  <bold>true</bold>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Upper Limit</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="1">
-               <widget class="PyDMLineEdit" name="PyDMLineEdit_48">
-                <property name="toolTip">
-                 <string/>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-                <property name="channel" stdset="0">
-                 <string>ca://${DEVICE}:PCORLOL</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="2">
-               <widget class="PyDMLineEdit" name="PyDMLineEdit_49">
-                <property name="toolTip">
-                 <string/>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-                <property name="channel" stdset="0">
-                 <string>ca://${DEVICE}:ACORUPL</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="2">
-               <widget class="PyDMLineEdit" name="PyDMLineEdit_50">
-                <property name="toolTip">
-                 <string/>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-                <property name="channel" stdset="0">
-                 <string>ca://${DEVICE}:ACORLOL</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="2">
-               <widget class="QLabel" name="label_46">
-                <property name="font">
-                 <font>
-                  <weight>75</weight>
-                  <bold>true</bold>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Amplitude Correction</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="3">
-               <widget class="PyDMLineEdit" name="PyDMLineEdit_51">
-                <property name="toolTip">
-                 <string/>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-                <property name="channel" stdset="0">
-                 <string>ca://${DEVICE}:ADRVUPL</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QLabel" name="label_45">
-                <property name="font">
-                 <font>
-                  <weight>75</weight>
-                  <bold>true</bold>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Phase Correction</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0">
-               <widget class="QLabel" name="label_49">
-                <property name="font">
-                 <font>
-                  <weight>75</weight>
-                  <bold>true</bold>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Lower Limit</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="PyDMLineEdit" name="PyDMLineEdit_47">
-                <property name="toolTip">
-                 <string/>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-                <property name="channel" stdset="0">
-                 <string>ca://${DEVICE}:PCORUPL</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="3">
-               <widget class="QLabel" name="label_47">
-                <property name="font">
-                 <font>
-                  <weight>75</weight>
-                  <bold>true</bold>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Amplitude Drive</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="3">
-               <widget class="PyDMLineEdit" name="PyDMLineEdit_52">
-                <property name="toolTip">
-                 <string/>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-                <property name="channel" stdset="0">
-                 <string>ca://${DEVICE}:ACORLOL</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="2">
-               <spacer name="verticalSpacer">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>20</width>
-                  <height>40</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-             </layout>
-            </item>
-            <item row="0" column="2">
-             <spacer name="horizontalSpacer_2">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="0" column="5" rowspan="3">
-             <layout class="QGridLayout" name="gridLayout_6">
-              <item row="2" column="3" colspan="2">
-               <widget class="PyDMLineEdit" name="PyDMLineEdit_45">
-                <property name="toolTip">
-                 <string/>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-                <property name="channel" stdset="0">
-                 <string>ca://${DEVICE}:PGAIN</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="2">
-               <widget class="QLabel" name="label_41">
-                <property name="font">
-                 <font>
-                  <pointsize>10</pointsize>
-                  <weight>75</weight>
-                  <bold>true</bold>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Phase Loop Gain</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="3" colspan="2">
-               <widget class="PyDMLineEdit" name="PyDMLineEdit_44">
-                <property name="toolTip">
-                 <string/>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-                <property name="channel" stdset="0">
-                 <string>ca://${DEVICE}:FBPOC</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="3" colspan="2">
-               <widget class="PyDMLineEdit" name="PyDMLineEdit_43">
-                <property name="toolTip">
-                 <string/>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-                <property name="channel" stdset="0">
-                 <string>ca://${DEVICE}:REFPOC</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="2">
-               <widget class="QLabel" name="label_39">
-                <property name="font">
-                 <font>
-                  <pointsize>10</pointsize>
-                  <weight>75</weight>
-                  <bold>true</bold>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Ref. POC</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="2">
-               <widget class="QLabel" name="label_42">
-                <property name="font">
-                 <font>
-                  <pointsize>10</pointsize>
-                  <weight>75</weight>
-                  <bold>true</bold>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Amplitude Loop Gain</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="2">
-               <widget class="QLabel" name="label_40">
-                <property name="font">
-                 <font>
-                  <pointsize>10</pointsize>
-                  <weight>75</weight>
-                  <bold>true</bold>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Feedback POC</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="3" colspan="2">
-               <widget class="PyDMLineEdit" name="PyDMLineEdit_46">
-                <property name="toolTip">
-                 <string/>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-                <property name="channel" stdset="0">
-                 <string>ca://${DEVICE}:AGAIN</string>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="2">
-               <widget class="QLabel" name="label_77">
-                <property name="font">
-                 <font>
-                  <pointsize>10</pointsize>
-                  <weight>75</weight>
-                  <bold>true</bold>
-                 </font>
-                </property>
-                <property name="text">
-                 <string>Beam Peak Voltage
-Conversion Factor(kV/Count)</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-                <property name="wordWrap">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="3" colspan="2">
-               <widget class="PyDMLineEdit" name="PyDMLineEdit_42">
-                <property name="toolTip">
-                 <string/>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-                <property name="channel" stdset="0">
-                 <string>ca://${DEVICE}:BVOLTCONV</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="5" column="0">
+       <item row="7" column="0">
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -3938,392 +4006,15 @@ Conversion Factor(kV/Count)</string>
          </property>
         </spacer>
        </item>
-       <item row="0" column="2" rowspan="5">
-        <layout class="QGridLayout" name="gridLayout_9" columnstretch="0,0">
-         <item row="5" column="0">
-          <widget class="PyDMWaveformPlot" name="PyDMWaveformPlot_6">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-             <horstretch>1</horstretch>
-             <verstretch>1</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="showXGrid">
-            <bool>true</bool>
-           </property>
-           <property name="showYGrid">
-            <bool>true</bool>
-           </property>
-           <property name="showLegend">
-            <bool>true</bool>
-           </property>
-           <property name="curves">
-            <stringlist>
-             <string>{&quot;y_channel&quot;: &quot;ca://${DEVICE}:ICPXWND1&quot;, &quot;x_channel&quot;: null, &quot;name&quot;: &quot;I&quot;, &quot;color&quot;: &quot;#ff557f&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
-             <string>{&quot;y_channel&quot;: &quot;ca://${DEVICE}:QCPXWND1&quot;, &quot;x_channel&quot;: null, &quot;name&quot;: &quot;Q&quot;, &quot;color&quot;: &quot;#5500ff&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
-            </stringlist>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <layout class="QHBoxLayout" name="horizontalLayout_3">
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <item>
-            <widget class="QLabel" name="label_57">
-             <property name="text">
-              <string>Feedback Complex Window</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton_2">
-             <property name="minimumSize">
-              <size>
-               <width>100</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>100</width>
-               <height>16777215</height>
-              </size>
-             </property>
-             <property name="toolTip">
-              <string/>
-             </property>
-             <property name="text">
-              <string>Define</string>
-             </property>
-             <property name="filenames" stdset="0">
-              <stringlist>
-               <string>define_complex_window.py</string>
-              </stringlist>
-             </property>
-             <property name="macros" stdset="0">
-              <stringlist>
-               <string>{&quot;TITLE&quot;:&quot;Baseband Complex Window&quot;, &quot;R&quot;:&quot;BL&quot;, &quot;N&quot;:&quot;&quot;}</string>
-              </stringlist>
-             </property>
-             <property name="openInNewWindow" stdset="0">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="8" column="0">
-          <widget class="PyDMWaveformPlot" name="PyDMWaveformPlot_7">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-             <horstretch>1</horstretch>
-             <verstretch>1</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="showXGrid">
-            <bool>true</bool>
-           </property>
-           <property name="showYGrid">
-            <bool>true</bool>
-           </property>
-           <property name="showLegend">
-            <bool>true</bool>
-           </property>
-           <property name="curves">
-            <stringlist>
-             <string>{&quot;y_channel&quot;: &quot;ca://${DEVICE}:ICPXWND2&quot;, &quot;x_channel&quot;: null, &quot;name&quot;: &quot;I&quot;, &quot;color&quot;: &quot;#ff557f&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
-             <string>{&quot;y_channel&quot;: &quot;ca://${DEVICE}:QCPXWND2&quot;, &quot;x_channel&quot;: null, &quot;name&quot;: &quot;Q&quot;, &quot;color&quot;: &quot;#5500ff&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
-            </stringlist>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="1">
-          <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="text">
-            <string>IQ Waveforms</string>
-           </property>
-           <property name="filenames" stdset="0">
-            <stringlist>
-             <string>iqwaveform.ui</string>
-             <string>iqwaveform.ui</string>
-             <string>iqwaveform.ui</string>
-             <string>iqwaveform.ui</string>
-             <string>iqwaveform.ui</string>
-             <string>iqwaveform.ui</string>
-             <string>iqwaveform.ui</string>
-             <string>iqwaveform.ui</string>
-             <string>iqwaveform.ui</string>
-             <string>iqwaveform.ui</string>
-            </stringlist>
-           </property>
-           <property name="titles" stdset="0">
-            <stringlist>
-             <string>IQ-Waveform - DwnCon:RF_IN_1</string>
-             <string>IQ-Waveform - DwnCon:RF_IN_2</string>
-             <string>IQ-Waveform - DwnCon:RF_IN_3</string>
-             <string>IQ-Waveform - DwnCon:RF_IN_4</string>
-             <string>IQ-Waveform - DwnCon:RF_IN_5</string>
-             <string>IQ-Waveform - DwnCon:RF_IN_6</string>
-             <string>IQ-Waveform - UpCon:RF_IN_1</string>
-             <string>IQ-Waveform - UpCon:RF_IN_2</string>
-             <string>IQ-Waveform - UpCon:RF_IN_3</string>
-             <string>IQ-Waveform - UpCon:RF_OUT_MON</string>
-            </stringlist>
-           </property>
-           <property name="macros" stdset="0">
-            <stringlist>
-             <string>{&quot;N&quot;:&quot;1&quot;}</string>
-             <string>{&quot;N&quot;:&quot;0&quot;}</string>
-             <string>{&quot;N&quot;:&quot;3&quot;}</string>
-             <string>{&quot;N&quot;:&quot;2&quot;}</string>
-             <string>{&quot;N&quot;:&quot;5&quot;}</string>
-             <string>{&quot;N&quot;:&quot;4&quot;}</string>
-             <string>{&quot;N&quot;:&quot;7&quot;}</string>
-             <string>{&quot;N&quot;:&quot;6&quot;}</string>
-             <string>{&quot;N&quot;:&quot;8&quot;}</string>
-             <string>{&quot;N&quot;:&quot;9&quot;}</string>
-            </stringlist>
-           </property>
-           <property name="openInNewWindow" stdset="0">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="PyDMWaveformPlot" name="PyDMWaveformPlot_5">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-             <horstretch>1</horstretch>
-             <verstretch>1</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="showXGrid">
-            <bool>true</bool>
-           </property>
-           <property name="showYGrid">
-            <bool>true</bool>
-           </property>
-           <property name="showLegend">
-            <bool>true</bool>
-           </property>
-           <property name="curves">
-            <stringlist>
-             <string>{&quot;y_channel&quot;: &quot;ca://${DEVICE}:ICPXWND0&quot;, &quot;x_channel&quot;: null, &quot;name&quot;: &quot;I&quot;, &quot;color&quot;: &quot;#ff557f&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
-             <string>{&quot;y_channel&quot;: &quot;ca://${DEVICE}:QCPXWND0&quot;, &quot;x_channel&quot;: null, &quot;name&quot;: &quot;Q&quot;, &quot;color&quot;: &quot;#5500ff&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
-            </stringlist>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="0">
-          <layout class="QHBoxLayout" name="horizontalLayout_5">
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <item>
-            <widget class="QLabel" name="label_59">
-             <property name="text">
-              <string>Diagnostics Complex Window 2</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton_4">
-             <property name="minimumSize">
-              <size>
-               <width>100</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>100</width>
-               <height>16777215</height>
-              </size>
-             </property>
-             <property name="toolTip">
-              <string/>
-             </property>
-             <property name="text">
-              <string>Define</string>
-             </property>
-             <property name="filenames" stdset="0">
-              <stringlist>
-               <string>define_complex_window.py</string>
-              </stringlist>
-             </property>
-             <property name="macros" stdset="0">
-              <stringlist>
-               <string>{&quot;TITLE&quot;:&quot;Baseband Complex Window&quot;, &quot;R&quot;:&quot;BL&quot;, &quot;N&quot;:&quot;&quot;}</string>
-              </stringlist>
-             </property>
-             <property name="openInNewWindow" stdset="0">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="4" column="0">
-          <layout class="QHBoxLayout" name="horizontalLayout_4">
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <item>
-            <widget class="QLabel" name="label_58">
-             <property name="text">
-              <string>Diagnostics Complex Window 1</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton_3">
-             <property name="minimumSize">
-              <size>
-               <width>100</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>100</width>
-               <height>16777215</height>
-              </size>
-             </property>
-             <property name="toolTip">
-              <string/>
-             </property>
-             <property name="text">
-              <string>Define</string>
-             </property>
-             <property name="filenames" stdset="0">
-              <stringlist>
-               <string>define_complex_window.py</string>
-              </stringlist>
-             </property>
-             <property name="macros" stdset="0">
-              <stringlist>
-               <string>{&quot;TITLE&quot;:&quot;Baseband Complex Window&quot;, &quot;R&quot;:&quot;BL&quot;, &quot;N&quot;:&quot;&quot;}</string>
-              </stringlist>
-             </property>
-             <property name="openInNewWindow" stdset="0">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="1" column="1">
-          <layout class="QHBoxLayout" name="horizontalLayout_2">
-           <item>
-            <widget class="QLabel" name="label_53">
-             <property name="text">
-              <string>Baseband I/Q Drive Waveforms</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton_5">
-             <property name="minimumSize">
-              <size>
-               <width>100</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>100</width>
-               <height>16777215</height>
-              </size>
-             </property>
-             <property name="toolTip">
-              <string/>
-             </property>
-             <property name="text">
-              <string>Define</string>
-             </property>
-             <property name="filenames" stdset="0">
-              <stringlist>
-               <string>define_complex_window.py</string>
-              </stringlist>
-             </property>
-             <property name="macros" stdset="0">
-              <stringlist>
-               <string>{&quot;TITLE&quot;:&quot;Baseband Complex Window&quot;, &quot;R&quot;:&quot;BL&quot;, &quot;N&quot;:&quot;&quot;}</string>
-              </stringlist>
-             </property>
-             <property name="openInNewWindow" stdset="0">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="2" column="1">
-          <widget class="PyDMWaveformPlot" name="PyDMWaveformPlot">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-             <horstretch>1</horstretch>
-             <verstretch>1</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="showXGrid">
-            <bool>true</bool>
-           </property>
-           <property name="showYGrid">
-            <bool>true</bool>
-           </property>
-           <property name="showLegend">
-            <bool>true</bool>
-           </property>
-           <property name="curves">
-            <stringlist>
-             <string>{&quot;y_channel&quot;: &quot;ca://${DEVICE}:IBL&quot;, &quot;x_channel&quot;: null, &quot;name&quot;: &quot;I&quot;, &quot;color&quot;: &quot;#ff557f&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
-             <string>{&quot;y_channel&quot;: &quot;ca://${DEVICE}:QBL&quot;, &quot;x_channel&quot;: null, &quot;name&quot;: &quot;Q&quot;, &quot;color&quot;: &quot;#5500ff&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
-            </stringlist>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="1">
-          <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton_9">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="text">
-            <string>See/Change Baseband I/Q Driver Waveforms</string>
-           </property>
-           <property name="filenames" stdset="0">
-            <stringlist>
-             <string>hls_complex_window.ui</string>
-            </stringlist>
-           </property>
-           <property name="macros" stdset="0">
-            <stringlist>
-             <string>{&quot;TITLE&quot;:&quot;Baseband I/Q Driver Waveforms&quot;, &quot;R&quot;:&quot;BL&quot;, &quot;N&quot;:&quot;&quot;}</string>
-            </stringlist>
-           </property>
-           <property name="openInNewWindow" stdset="0">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
+       <item row="3" column="0">
+        <widget class="Line" name="line">
+         <property name="lineWidth">
+          <number>4</number>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>
@@ -4336,11 +4027,6 @@ Conversion Factor(kV/Count)</string>
    <class>PyDMLabel</class>
    <extends>QLabel</extends>
    <header>pydm.widgets.label</header>
-  </customwidget>
-  <customwidget>
-   <class>PyDMWaveformPlot</class>
-   <extends>QGraphicsView</extends>
-   <header>pydm.widgets.waveformplot</header>
   </customwidget>
   <customwidget>
    <class>PyDMEnumButton</class>

--- a/llrf_hls.ui
+++ b/llrf_hls.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1145</width>
+    <width>1222</width>
     <height>1266</height>
    </rect>
   </property>
@@ -36,7 +36,7 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>1133</width>
+        <width>1210</width>
         <height>1254</height>
        </rect>
       </property>


### PR DESCRIPTION
This resolves #123 .

The complex windows are now available on independent related display. The HLS display now has buttons to access this new displays.